### PR TITLE
Enhance TOC styling

### DIFF
--- a/src/components/ReportViewer.tsx
+++ b/src/components/ReportViewer.tsx
@@ -1,16 +1,7 @@
 // components/ReportViewer.tsx
 'use client';
 import { reportData } from '@/data/report';
-import {
-  BarChart2,
-  BookOpen,
-  ChevronRight,
-  FlaskConical,
-  GraduationCap,
-  Handshake,
-  HeartHandshake,
-  Lightbulb
-} from 'lucide-react';
+
 import { useEffect, useState } from 'react';
 import CoverPage from './CoverPage';
 import TableOfContents from './TableOfContents';
@@ -48,18 +39,15 @@ const ReportViewer = () => {
 
   // Generate TOC items
   const tocItems = [
-    { id: 'message', title: reportData.message.title, icon: <BookOpen size={16} /> },
-    { id: 'impact', title: "Our Impact at a Glance", icon: <BarChart2 size={16} /> },
-    { id: 'vision', title: "Our Strategic Vision", icon: <Lightbulb size={16} /> },
+    { id: 'message', title: reportData.message.title },
+    { id: 'impact', title: 'Our Impact at a Glance' },
+    { id: 'vision', title: 'Our Strategic Vision' },
     ...reportData.sections.map((section, i) => ({
-      id: `section-${i+1}`,
-      title: `${i+1}. ${section.title}`,
-      icon: i === 0 ? <GraduationCap size={16} /> : 
-             i === 1 ? <FlaskConical size={16} /> : 
-             <Handshake size={16} />
+      id: `section-${i + 1}`,
+      title: section.title
     })),
-    { id: 'future', title: "Looking Ahead", icon: <ChevronRight size={16} /> },
-    { id: 'thankyou', title: "Thank You", icon: <HeartHandshake size={16} /> }
+    { id: 'future', title: 'Looking Ahead' },
+    { id: 'thankyou', title: 'Thank You' }
   ];
 
   return (

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -5,7 +5,6 @@ import { BookOpen } from 'lucide-react'
 interface TocItem {
   id: string
   title: string
-  icon: React.ReactNode
 }
 
 interface Props {
@@ -15,13 +14,13 @@ interface Props {
 }
 
 const TableOfContents = ({ items, active, setActive }: Props) => (
-  <div className="mb-20 p-8 bg-gradient-to-br from-emerald-50 to-blue-50 rounded-2xl border border-emerald-200 shadow-sm print:hidden mx-8">
+  <div className="mb-20 p-8 bg-gradient-to-br from-emerald-50 to-blue-50 rounded-2xl border border-emerald-200 shadow-sm mx-8">
     <h2 className="text-3xl font-bold text-slate-800 mb-6 flex items-center">
       <BookOpen className="mr-3 text-emerald-600" size={32} />
       Table of Contents
     </h2>
     <ul className="space-y-3">
-      {items.map(item => (
+      {items.map((item, index) => (
         <li key={item.id}>
           <a
             href={`#${item.id}`}
@@ -34,7 +33,9 @@ const TableOfContents = ({ items, active, setActive }: Props) => (
               active === item.id ? 'bg-emerald-100 text-emerald-700 font-bold' : 'hover:bg-emerald-50'
             }`}
           >
-            <span className="mr-3 text-emerald-600">{item.icon}</span>
+            <span className="mr-3 flex items-center justify-center w-8 h-8 rounded-full bg-emerald-600 text-white font-semibold">
+              {index + 1}
+            </span>
             <span>{item.title}</span>
           </a>
         </li>


### PR DESCRIPTION
## Summary
- refactor Table of Contents items to use numbered badges instead of icons
- keep TOC visible when printing
- simplify TOC item generation

## Testing
- `npm run lint`
- `npm run build` *(fails: 'reportData.closingImage' is possibly undefined)*

------
https://chatgpt.com/codex/tasks/task_e_685f2792fe348321a3a5723d8779ade4