### PR TITLE
Improve TOC print layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -39,6 +39,10 @@ body {
   .print\:break-before {
     page-break-before: always;
   }
+
+  .print\:break-after {
+    page-break-after: always;
+  }
   
   .print\:break-inside-avoid {
     page-break-inside: avoid;

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -13,35 +13,47 @@ interface Props {
   setActive: Dispatch<SetStateAction<string>>
 }
 
-const TableOfContents = ({ items, active, setActive }: Props) => (
-  <div className="mb-20 p-8 bg-gradient-to-br from-emerald-50 to-blue-50 rounded-2xl border border-emerald-200 shadow-sm mx-8">
-    <h2 className="text-3xl font-bold text-slate-800 mb-6 flex items-center">
-      <BookOpen className="mr-3 text-emerald-600" size={32} />
-      Table of Contents
-    </h2>
-    <ul className="space-y-3">
-      {items.map((item, index) => (
-        <li key={item.id}>
-          <a
+const TableOfContents = ({ items, active, setActive }: Props) => {
+  const circleColor = (index: number) => {
+    const startHue = 160
+    const endHue = 220
+    const hue = startHue + ((endHue - startHue) * index) / Math.max(items.length - 1, 1)
+    return `hsl(${hue}, 70%, 45%)`
+  }
+
+  return (
+    <div className="mb-20 p-8 mx-8 print:break-before print:break-after">
+      <h2 className="text-3xl font-bold text-slate-800 mb-6 flex items-center">
+        <BookOpen className="mr-3 text-emerald-600" size={32} />
+        Table of Contents
+      </h2>
+      <ul className="space-y-3">
+        {items.map((item, index) => (
+          <li key={item.id}>
+            <a
             href={`#${item.id}`}
             onClick={e => {
               e.preventDefault()
               document.getElementById(item.id)?.scrollIntoView({ behavior: 'smooth' })
               setActive(item.id)
             }}
-            className={`flex items-center p-3 rounded-lg transition-all ${
-              active === item.id ? 'bg-emerald-100 text-emerald-700 font-bold' : 'hover:bg-emerald-50'
-            }`}
-          >
-            <span className="mr-3 flex items-center justify-center w-8 h-8 rounded-full bg-emerald-600 text-white font-semibold">
-              {index + 1}
-            </span>
-            <span>{item.title}</span>
-          </a>
-        </li>
-      ))}
-    </ul>
-  </div>
-)
+              className={`flex items-center p-3 rounded-lg transition-all ${
+                active === item.id ? 'bg-emerald-100 text-emerald-700 font-bold' : 'hover:bg-emerald-50'
+              }`}
+            >
+              <span
+                className="mr-3 flex items-center justify-center w-8 h-8 rounded-full text-white font-semibold"
+                style={{ backgroundColor: circleColor(index) }}
+              >
+                {index + 1}
+              </span>
+              <span>{item.title}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
 
 export default TableOfContents


### PR DESCRIPTION
## Summary
- ensure Table of Contents starts and ends on its own page when printing
- remove card styling from the TOC component
- add gradient-colored numbering circles

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f2af45f608321af103d5969881486