### PR TITLE
Add padding after cover page

### DIFF
--- a/src/components/ReportViewer.tsx
+++ b/src/components/ReportViewer.tsx
@@ -53,8 +53,12 @@ const ReportViewer = () => {
   return (
     <div className="max-w-5xl mx-auto bg-white font-serif text-gray-700 relative">
       <CoverPage />
-      <TableOfContents items={tocItems} active={activeSection} setActive={setActiveSection} />
-      <div className="px-8 print:px-0">
+      <div className="p-8 space-y-16 print:p-0">
+        <TableOfContents
+          items={tocItems}
+          active={activeSection}
+          setActive={setActiveSection}
+        />
         <GuidingMission />
         <MessageSection />
         <ImpactSection />


### PR DESCRIPTION
## Summary
- wrap Table of Contents and the rest of the report in a padded container

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685f2b8f853c832184a631002ba874c9