### PR TITLE
Ensure closing section starts on its own page

### DIFF
--- a/src/components/ClosingSection.tsx
+++ b/src/components/ClosingSection.tsx
@@ -2,7 +2,7 @@
 import { reportData } from '@/data/report'
 
 const ClosingSection = () => (
-  <div id="thankyou" className="text-center py-16 border-t border-emerald-100 scroll-mt-20">
+  <div id="thankyou" className="text-center py-16 border-t border-emerald-100 scroll-mt-20 print:break-before">
     <h3 className="text-3xl font-bold text-slate-800 mb-6">A Heartfelt Thank You</h3>
     <p className="text-xl text-slate-600 max-w-3xl mx-auto">{reportData.closing}</p>
     <div className="mt-12 max-w-3xl mx-auto print:break-inside-avoid">


### PR DESCRIPTION
## Summary
- start the "Thank You" section on a new page when printing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685f2bbd9ac48321bef73c10c503afa7