### PR TITLE
Add heading numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
-## Getting Started
+## 1. Getting Started
 
 First, run the development server:
 
@@ -20,7 +20,7 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
-## Learn More
+## 2. Learn More
 
 To learn more about Next.js, take a look at the following resources:
 
@@ -29,7 +29,7 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
-## Deploy on Vercel
+## 3. Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 

--- a/src/components/ClosingSection.tsx
+++ b/src/components/ClosingSection.tsx
@@ -1,16 +1,20 @@
 'use client'
 import { reportData } from '@/data/report'
 
-const ClosingSection = () => (
+interface Props { number: number }
+
+const ClosingSection = ({ number }: Props) => (
   <div id="thankyou" className="text-center py-16 border-t border-emerald-100 scroll-mt-20 print:break-before">
-    <h3 className="text-3xl font-bold text-slate-800 mb-6">A Heartfelt Thank You</h3>
+    <h3 className="text-3xl font-bold text-slate-800 mb-6">{number}. A Heartfelt Thank You</h3>
     <p className="text-xl text-slate-600 max-w-3xl mx-auto">{reportData.closing}</p>
-    <div className="mt-12 max-w-3xl mx-auto print:break-inside-avoid">
-      <div className="relative w-full h-96 rounded-2xl overflow-hidden shadow-xl">
-        <img src={reportData.closingImage.src} alt={reportData.closingImage.alt} className="w-full h-full object-cover" />
+    {reportData.closingImage && (
+      <div className="mt-12 max-w-3xl mx-auto print:break-inside-avoid">
+        <div className="relative w-full h-96 rounded-2xl overflow-hidden shadow-xl">
+          <img src={reportData.closingImage.src} alt={reportData.closingImage.alt} className="w-full h-full object-cover" />
+        </div>
+        <p className="text-center text-sm text-gray-600 italic mt-2">{reportData.closingImage.caption}</p>
       </div>
-      <p className="text-center text-sm text-gray-600 italic mt-2">{reportData.closingImage.caption}</p>
-    </div>
+    )}
   </div>
 )
 

--- a/src/components/ContentRenderer.tsx
+++ b/src/components/ContentRenderer.tsx
@@ -2,7 +2,21 @@
 import React from 'react'
 import { ContentItem } from '@/types/report'
 
-const ContentRenderer = ({ content, index }: { content: ContentItem | string; index: number }) => {
+interface Props {
+  content: ContentItem | string
+  index: number
+  subheadingNumber?: string
+}
+
+const ContentRenderer = ({ content, index, subheadingNumber }: Props) => {
+  if (typeof content === 'string') {
+    return (
+      <p key={index} className="text-lg mb-4 text-gray-700">
+        {content}
+      </p>
+    )
+  }
+
   switch (content.type) {
     case 'paragraph':
       return <p key={index} className="mb-4 text-lg leading-relaxed text-gray-700">{content.text}</p>;
@@ -22,7 +36,12 @@ const ContentRenderer = ({ content, index }: { content: ContentItem | string; in
         </ul>
       );
     case 'subheading':
-      return <h3 key={index} className="text-2xl font-bold text-slate-800 mt-8 mb-4">{content.text}</h3>;
+      return (
+        <h3 key={index} className="text-2xl font-bold text-slate-800 mt-8 mb-4">
+          {subheadingNumber ? `${subheadingNumber} ` : ''}
+          {content.text}
+        </h3>
+      );
     case 'bold':
       return <strong key={index} className="font-semibold text-emerald-700">{content.text}</strong>;
     case 'image':
@@ -43,9 +62,6 @@ const ContentRenderer = ({ content, index }: { content: ContentItem | string; in
         </figure>
       );
     default:
-      if (typeof content === 'string') {
-        return <p key={index} className="text-lg mb-4 text-gray-700">{content}</p>;
-      }
       return null;
   }
 };

--- a/src/components/FutureGoalsSection.tsx
+++ b/src/components/FutureGoalsSection.tsx
@@ -2,11 +2,13 @@
 import { reportData } from '@/data/report'
 import { ChevronRight } from 'lucide-react'
 
-const FutureGoalsSection = () => (
+interface Props { number: number }
+
+const FutureGoalsSection = ({ number }: Props) => (
   <div id="future" className="mb-20 scroll-mt-20">
     <h2 className="text-3xl font-bold text-slate-800 mb-10 flex items-center">
       <ChevronRight className="mr-3 text-emerald-600" size={32} />
-      Looking Ahead: Our Goals for H2 2025
+      {number}. Looking Ahead: Our Goals for H2 2025
     </h2>
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
       {reportData.futureGoals.map((goal, index) => (

--- a/src/components/ImpactSection.tsx
+++ b/src/components/ImpactSection.tsx
@@ -2,11 +2,13 @@
 import { reportData } from '@/data/report'
 import { BarChart2 } from 'lucide-react'
 
-const ImpactSection = () => (
+interface Props { number: number }
+
+const ImpactSection = ({ number }: Props) => (
   <div id="impact" className="mb-20 scroll-mt-20">
     <h2 className="text-3xl font-bold text-slate-800 mb-10 flex items-center">
       <BarChart2 className="mr-3 text-emerald-600" size={32} />
-      Our Impact at a Glance
+      {number}. Our Impact at a Glance
     </h2>
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
       {reportData.milestones.map((milestone, index) => (

--- a/src/components/MessageSection.tsx
+++ b/src/components/MessageSection.tsx
@@ -2,9 +2,15 @@
 import ContentRenderer from './ContentRenderer'
 import { reportData } from '@/data/report'
 
-const MessageSection = () => (
+interface Props {
+  number: number
+}
+
+const MessageSection = ({ number }: Props) => (
   <div id="message" className="mb-20 scroll-mt-20">
-    <h2 className="text-3xl font-bold text-slate-800 mb-6">{reportData.message.title}</h2>
+    <h2 className="text-3xl font-bold text-slate-800 mb-6">
+      {number}. {reportData.message.title}
+    </h2>
     {reportData.message.content.map((content, index) => (
       <ContentRenderer key={index} content={content} index={index} />
     ))}

--- a/src/components/ReportViewer.tsx
+++ b/src/components/ReportViewer.tsx
@@ -50,6 +50,11 @@ const ReportViewer = () => {
     { id: 'thankyou', title: 'Thank You' }
   ];
 
+  const sectionNumbers = tocItems.reduce<Record<string, number>>((acc, item, idx) => {
+    acc[item.id] = idx + 1;
+    return acc;
+  }, {});
+
   return (
     <div className="max-w-5xl mx-auto bg-white font-serif text-gray-700 relative">
       <CoverPage />
@@ -60,12 +65,12 @@ const ReportViewer = () => {
           setActive={setActiveSection}
         />
         <GuidingMission />
-        <MessageSection />
-        <ImpactSection />
-        <StrategicVisionSection />
-        <Sections />
-        <FutureGoalsSection />
-        <ClosingSection />
+        <MessageSection number={sectionNumbers['message']} />
+        <ImpactSection number={sectionNumbers['impact']} />
+        <StrategicVisionSection number={sectionNumbers['vision']} />
+        <Sections startNumber={sectionNumbers['section-1']} />
+        <FutureGoalsSection number={sectionNumbers['future']} />
+        <ClosingSection number={sectionNumbers['thankyou']} />
       </div>
     </div>
   );

--- a/src/components/Sections.tsx
+++ b/src/components/Sections.tsx
@@ -1,20 +1,38 @@
 'use client'
 import { reportData } from '@/data/report'
 import ContentRenderer from './ContentRenderer'
+import { ContentItem } from '@/types/report'
+interface Props {
+  startNumber: number
+}
 
-const Sections = () => (
+const Sections = ({ startNumber }: Props) => (
   <>
     {reportData.sections.map((section, sectionIndex) => {
+      const sectionNumber = startNumber + sectionIndex
       const sectionId = `section-${sectionIndex + 1}`
+      let subIndex = 0
       return (
         <div key={sectionIndex} id={sectionId} className="mb-20 scroll-mt-20">
           <h2 className="text-3xl font-bold text-slate-800 mb-10">
-            {sectionIndex + 1}. {section.title}
+            {sectionNumber}. {section.title}
           </h2>
           <div className="space-y-6">
-            {section.content.map((content, contentIndex) => (
-              <ContentRenderer key={contentIndex} content={content} index={contentIndex} />
-            ))}
+            {section.content.map((content, contentIndex) => {
+              let subNumber: string | undefined
+              if ((content as ContentItem).type === 'subheading') {
+                subIndex += 1
+                subNumber = `${sectionNumber}.${subIndex}`
+              }
+              return (
+                <ContentRenderer
+                  key={contentIndex}
+                  content={content}
+                  index={contentIndex}
+                  subheadingNumber={subNumber}
+                />
+              )
+            })}
           </div>
         </div>
       )

--- a/src/components/StrategicVisionSection.tsx
+++ b/src/components/StrategicVisionSection.tsx
@@ -2,9 +2,13 @@
 import { reportData } from '@/data/report'
 import { GraduationCap, Handshake } from 'lucide-react'
 
-const StrategicVisionSection = () => (
+interface Props { number: number }
+
+const StrategicVisionSection = ({ number }: Props) => (
   <div id="vision" className="mb-20 scroll-mt-20">
-    <h2 className="text-3xl font-bold text-slate-800 mb-6">Our Strategic Vision: A Blueprint for a Brighter Future</h2>
+    <h2 className="text-3xl font-bold text-slate-800 mb-6">
+      {number}. Our Strategic Vision: A Blueprint for a Brighter Future
+    </h2>
     <p className="text-lg mb-8">{reportData.strategicVision.intro}</p>
 
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">


### PR DESCRIPTION
## Summary
- number README headings
- support numbered section headings and subheadings
- show section numbers across main report components

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f2e27ad288321859bf8627359a0d1