### PR TITLE
Add print padding after cover page

### DIFF
--- a/src/components/ReportViewer.tsx
+++ b/src/components/ReportViewer.tsx
@@ -53,7 +53,7 @@ const ReportViewer = () => {
   return (
     <div className="max-w-5xl mx-auto bg-white font-serif text-gray-700 relative">
       <CoverPage />
-      <div className="p-8 space-y-16 print:p-0">
+      <div className="p-8 space-y-16 print:p-[1.5cm]">
         <TableOfContents
           items={tocItems}
           active={activeSection}


### PR DESCRIPTION
## Summary
- add 1.5cm print padding for all pages after the cover page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685f2f64608c83218f9513b2748dcee5