### PR TITLE
Add editable report view

### DIFF
--- a/src/app/edit/page.tsx
+++ b/src/app/edit/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+import ReportEditor from '@/components/ReportEditor'
+
+const EditPage = () => {
+  return <ReportEditor />
+}
+
+export default EditPage

--- a/src/components/EditableContentItem.tsx
+++ b/src/components/EditableContentItem.tsx
@@ -1,0 +1,80 @@
+'use client'
+import React from 'react'
+import { ContentItem } from '@/types/report'
+
+interface Props {
+  item: ContentItem
+  onChange: (item: ContentItem) => void
+}
+
+const EditableContentItem = ({ item, onChange }: Props) => {
+  switch (item.type) {
+    case 'paragraph':
+      return (
+        <textarea
+          className="w-full border rounded p-2"
+          value={item.text}
+          onChange={(e) => onChange({ ...item, text: e.target.value })}
+        />
+      )
+    case 'quote':
+      return (
+        <div className="space-y-2">
+          <textarea
+            className="w-full border rounded p-2"
+            value={item.text}
+            onChange={(e) => onChange({ ...item, text: e.target.value })}
+          />
+          <input
+            className="w-full border rounded p-2"
+            value={item.author}
+            onChange={(e) => onChange({ ...item, author: e.target.value })}
+          />
+        </div>
+      )
+    case 'list':
+      return (
+        <textarea
+          className="w-full border rounded p-2"
+          value={item.items.join('\n')}
+          onChange={(e) => onChange({ ...item, items: e.target.value.split('\n') })}
+        />
+      )
+    case 'subheading':
+    case 'bold':
+      return (
+        <input
+          className="w-full border rounded p-2"
+          value={item.text}
+          onChange={(e) => onChange({ ...item, text: e.target.value })}
+        />
+      )
+    case 'image':
+      return (
+        <div className="space-y-2">
+          <input
+            className="w-full border rounded p-2"
+            placeholder="src"
+            value={item.src}
+            onChange={(e) => onChange({ ...item, src: e.target.value })}
+          />
+          <input
+            className="w-full border rounded p-2"
+            placeholder="alt"
+            value={item.alt}
+            onChange={(e) => onChange({ ...item, alt: e.target.value })}
+          />
+          <input
+            className="w-full border rounded p-2"
+            placeholder="caption"
+            value={item.caption}
+            onChange={(e) => onChange({ ...item, caption: e.target.value })}
+          />
+        </div>
+      )
+    default:
+      return null
+  }
+}
+
+export default EditableContentItem

--- a/src/components/ReportEditor.tsx
+++ b/src/components/ReportEditor.tsx
@@ -1,0 +1,83 @@
+'use client'
+import React from 'react'
+import useEditableReportData from '@/hooks/useEditableReportData'
+import { ContentItem } from '@/types/report'
+import EditableContentItem from './EditableContentItem'
+
+const ReportEditor = () => {
+  const { data, setData, save } = useEditableReportData()
+
+  if (!data) return <p>Loading...</p>
+
+  const updateMessageItem = (idx: number, value: string | ContentItem) => {
+    const newData = { ...data }
+    newData.message.content[idx] = value
+    setData(newData)
+  }
+
+  const updateSectionItem = (
+    sectionIndex: number,
+    itemIndex: number,
+    item: ContentItem
+  ) => {
+    const newData = { ...data }
+    newData.sections[sectionIndex].content[itemIndex] = item
+    setData(newData)
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto p-4 space-y-8">
+      <h1 className="text-2xl font-bold">Edit Report</h1>
+
+      <div className="space-y-4">
+        <h2 className="font-semibold text-xl">Message</h2>
+        {data.message.content.map((c, i) =>
+          typeof c === 'string' ? (
+            <textarea
+              key={i}
+              className="w-full border rounded p-2"
+              value={c}
+              onChange={(e) => updateMessageItem(i, e.target.value)}
+            />
+          ) : (
+            <EditableContentItem
+              key={i}
+              item={c}
+              onChange={(val) => updateMessageItem(i, val)}
+            />
+          )
+        )}
+      </div>
+
+      {data.sections.map((section, sIdx) => (
+        <div key={sIdx} className="space-y-4 border-t pt-4">
+          <input
+            className="w-full border rounded p-2 font-semibold"
+            value={section.title}
+            onChange={(e) => {
+              const newData = { ...data }
+              newData.sections[sIdx].title = e.target.value
+              setData(newData)
+            }}
+          />
+          {section.content.map((item, cIdx) => (
+            <EditableContentItem
+              key={cIdx}
+              item={item as ContentItem}
+              onChange={(val) => updateSectionItem(sIdx, cIdx, val)}
+            />
+          ))}
+        </div>
+      ))}
+
+      <button
+        className="px-4 py-2 bg-emerald-600 text-white rounded"
+        onClick={() => save(data)}
+      >
+        Save
+      </button>
+    </div>
+  )
+}
+
+export default ReportEditor

--- a/src/hooks/useEditableReportData.ts
+++ b/src/hooks/useEditableReportData.ts
@@ -1,0 +1,28 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { ReportData } from '@/types/report'
+import { db, REPORT_ID } from '@/utils/db'
+
+// Hook that loads report data from Dexie and allows saving updates
+const useEditableReportData = () => {
+  const [data, setData] = useState<ReportData | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      const existing = await db.table('report').get(REPORT_ID)
+      if (existing) {
+        setData(existing as ReportData)
+      }
+    }
+    load()
+  }, [])
+
+  const save = async (newData: ReportData) => {
+    await db.table('report').put({ ...(newData as ReportData), id: REPORT_ID })
+    setData(newData)
+  }
+
+  return { data, setData, save }
+}
+
+export default useEditableReportData


### PR DESCRIPTION
## Summary
- add `useEditableReportData` hook for editing and saving to Dexie
- create `EditableContentItem` to edit paragraph, quote, list, subheading, bold and image blocks
- implement `ReportEditor` with save button
- add an `/edit` route that renders the editor

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f37a6cc788321b9c8f73f1cddfc64