### PR TITLE
Add floating edit toggle

### DIFF
--- a/src/app/edit/page.tsx
+++ b/src/app/edit/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+import ReportEditor from '@/components/ReportEditor'
+
+const EditPage = () => {
+  return <ReportEditor />
+}
+
+export default EditPage

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Inter } from "next/font/google";
 import "./globals.css";
+import EditToggle from "@/components/EditToggle";
 
 
 const inter = Inter({ subsets: ['latin'] });
@@ -20,6 +21,7 @@ export default function RootLayout({
         className={inter.className}
       >
         {children}
+        <EditToggle />
       </body>
     </html>
   );

--- a/src/components/EditToggle.tsx
+++ b/src/components/EditToggle.tsx
@@ -1,0 +1,38 @@
+'use client'
+import { useRouter, usePathname } from 'next/navigation'
+import { useEffect, useState } from 'react'
+
+const EditToggle = () => {
+  const router = useRouter()
+  const pathname = usePathname()
+  const [editing, setEditing] = useState(false)
+
+  useEffect(() => {
+    setEditing(pathname.startsWith('/edit'))
+  }, [pathname])
+
+  const toggle = () => {
+    if (editing) {
+      router.push('/')
+    } else {
+      router.push('/edit')
+    }
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 flex items-center space-x-2 z-50">
+      <span className="text-sm font-medium text-gray-700">{editing ? 'Editing' : 'View'}</span>
+      <label className="relative inline-flex items-center cursor-pointer">
+        <input
+          type="checkbox"
+          checked={editing}
+          onChange={toggle}
+          className="sr-only peer"
+        />
+        <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-emerald-500 rounded-full peer dark:bg-gray-300 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-emerald-600"></div>
+      </label>
+    </div>
+  )
+}
+
+export default EditToggle

--- a/src/components/EditableContentItem.tsx
+++ b/src/components/EditableContentItem.tsx
@@ -1,0 +1,80 @@
+'use client'
+import React from 'react'
+import { ContentItem } from '@/types/report'
+
+interface Props {
+  item: ContentItem
+  onChange: (item: ContentItem) => void
+}
+
+const EditableContentItem = ({ item, onChange }: Props) => {
+  switch (item.type) {
+    case 'paragraph':
+      return (
+        <textarea
+          className="w-full border rounded p-2"
+          value={item.text}
+          onChange={(e) => onChange({ ...item, text: e.target.value })}
+        />
+      )
+    case 'quote':
+      return (
+        <div className="space-y-2">
+          <textarea
+            className="w-full border rounded p-2"
+            value={item.text}
+            onChange={(e) => onChange({ ...item, text: e.target.value })}
+          />
+          <input
+            className="w-full border rounded p-2"
+            value={item.author}
+            onChange={(e) => onChange({ ...item, author: e.target.value })}
+          />
+        </div>
+      )
+    case 'list':
+      return (
+        <textarea
+          className="w-full border rounded p-2"
+          value={item.items.join('\n')}
+          onChange={(e) => onChange({ ...item, items: e.target.value.split('\n') })}
+        />
+      )
+    case 'subheading':
+    case 'bold':
+      return (
+        <input
+          className="w-full border rounded p-2"
+          value={item.text}
+          onChange={(e) => onChange({ ...item, text: e.target.value })}
+        />
+      )
+    case 'image':
+      return (
+        <div className="space-y-2">
+          <input
+            className="w-full border rounded p-2"
+            placeholder="src"
+            value={item.src}
+            onChange={(e) => onChange({ ...item, src: e.target.value })}
+          />
+          <input
+            className="w-full border rounded p-2"
+            placeholder="alt"
+            value={item.alt}
+            onChange={(e) => onChange({ ...item, alt: e.target.value })}
+          />
+          <input
+            className="w-full border rounded p-2"
+            placeholder="caption"
+            value={item.caption}
+            onChange={(e) => onChange({ ...item, caption: e.target.value })}
+          />
+        </div>
+      )
+    default:
+      return null
+  }
+}
+
+export default EditableContentItem

--- a/src/components/ReportEditor.tsx
+++ b/src/components/ReportEditor.tsx
@@ -1,0 +1,83 @@
+'use client'
+import React from 'react'
+import useEditableReportData from '@/hooks/useEditableReportData'
+import { ContentItem } from '@/types/report'
+import EditableContentItem from './EditableContentItem'
+
+const ReportEditor = () => {
+  const { data, setData, save } = useEditableReportData()
+
+  if (!data) return <p>Loading...</p>
+
+  const updateMessageItem = (idx: number, value: string | ContentItem) => {
+    const newData = { ...data }
+    newData.message.content[idx] = value
+    setData(newData)
+  }
+
+  const updateSectionItem = (
+    sectionIndex: number,
+    itemIndex: number,
+    item: ContentItem
+  ) => {
+    const newData = { ...data }
+    newData.sections[sectionIndex].content[itemIndex] = item
+    setData(newData)
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto p-4 space-y-8">
+      <h1 className="text-2xl font-bold">Edit Report</h1>
+
+      <div className="space-y-4">
+        <h2 className="font-semibold text-xl">Message</h2>
+        {data.message.content.map((c, i) =>
+          typeof c === 'string' ? (
+            <textarea
+              key={i}
+              className="w-full border rounded p-2"
+              value={c}
+              onChange={(e) => updateMessageItem(i, e.target.value)}
+            />
+          ) : (
+            <EditableContentItem
+              key={i}
+              item={c}
+              onChange={(val) => updateMessageItem(i, val)}
+            />
+          )
+        )}
+      </div>
+
+      {data.sections.map((section, sIdx) => (
+        <div key={sIdx} className="space-y-4 border-t pt-4">
+          <input
+            className="w-full border rounded p-2 font-semibold"
+            value={section.title}
+            onChange={(e) => {
+              const newData = { ...data }
+              newData.sections[sIdx].title = e.target.value
+              setData(newData)
+            }}
+          />
+          {section.content.map((item, cIdx) => (
+            <EditableContentItem
+              key={cIdx}
+              item={item as ContentItem}
+              onChange={(val) => updateSectionItem(sIdx, cIdx, val)}
+            />
+          ))}
+        </div>
+      ))}
+
+      <button
+        className="px-4 py-2 bg-emerald-600 text-white rounded"
+        onClick={() => save(data)}
+      >
+        Save
+      </button>
+    </div>
+  )
+}
+
+export default ReportEditor

--- a/src/hooks/useEditableReportData.ts
+++ b/src/hooks/useEditableReportData.ts
@@ -1,0 +1,28 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { ReportData } from '@/types/report'
+import { db, REPORT_ID } from '@/utils/db'
+
+// Hook that loads report data from Dexie and allows saving updates
+const useEditableReportData = () => {
+  const [data, setData] = useState<ReportData | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      const existing = await db.table('report').get(REPORT_ID)
+      if (existing) {
+        setData(existing as ReportData)
+      }
+    }
+    load()
+  }, [])
+
+  const save = async (newData: ReportData) => {
+    await db.table('report').put({ ...(newData as ReportData), id: REPORT_ID })
+    setData(newData)
+  }
+
+  return { data, setData, save }
+}
+
+export default useEditableReportData


### PR DESCRIPTION
## Summary
- add `EditToggle` component to switch between view and edit mode
- include floating toggle in `RootLayout`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f37a6cc788321b9c8f73f1cddfc64