### PR TITLE
Add floating edit toggle

### DIFF
--- a/src/app/edit/page.tsx
+++ b/src/app/edit/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+import ReportEditor from '@/components/ReportEditor'
+
+const EditPage = () => {
+  return <ReportEditor />
+}
+
+export default EditPage

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Inter } from "next/font/google";
 import "./globals.css";
+import EditToggle from "@/components/EditToggle";
 
 
 const inter = Inter({ subsets: ['latin'] });
@@ -20,6 +21,7 @@ export default function RootLayout({
         className={inter.className}
       >
         {children}
+        <EditToggle />
       </body>
     </html>
   );

--- a/src/components/EditToggle.tsx
+++ b/src/components/EditToggle.tsx
@@ -1,0 +1,38 @@
+'use client'
+import { useRouter, usePathname } from 'next/navigation'
+import { useEffect, useState } from 'react'
+
+const EditToggle = () => {
+  const router = useRouter()
+  const pathname = usePathname()
+  const [editing, setEditing] = useState(false)
+
+  useEffect(() => {
+    setEditing(pathname.startsWith('/edit'))
+  }, [pathname])
+
+  const toggle = () => {
+    if (editing) {
+      router.push('/')
+    } else {
+      router.push('/edit')
+    }
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 flex items-center space-x-2 z-50">
+      <span className="text-sm font-medium text-gray-700">{editing ? 'Editing' : 'View'}</span>
+      <label className="relative inline-flex items-center cursor-pointer">
+        <input
+          type="checkbox"
+          checked={editing}
+          onChange={toggle}
+          className="sr-only peer"
+        />
+        <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-emerald-500 rounded-full peer dark:bg-gray-300 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-emerald-600"></div>
+      </label>
+    </div>
+  )
+}
+
+export default EditToggle

--- a/src/components/EditableContentRenderer.tsx
+++ b/src/components/EditableContentRenderer.tsx
@@ -1,0 +1,164 @@
+'use client'
+import React from 'react'
+import { ContentItem } from '@/types/report'
+
+interface Props {
+  content: ContentItem | string
+  index: number
+  onChange: (value: ContentItem | string) => void
+  subheadingNumber?: string
+}
+
+const EditableContentRenderer = ({ content, index, onChange, subheadingNumber }: Props) => {
+  if (typeof content === 'string') {
+    return (
+      <p
+        key={index}
+        className="mb-4 text-lg leading-relaxed text-gray-700 border rounded p-1"
+        contentEditable
+        suppressContentEditableWarning
+        onInput={(e) => onChange(e.currentTarget.textContent || '')}
+      >
+        {content}
+      </p>
+    )
+  }
+
+  switch (content.type) {
+    case 'paragraph':
+      return (
+        <p
+          key={index}
+          className="mb-4 text-lg leading-relaxed text-gray-700 border rounded p-1"
+          contentEditable
+          suppressContentEditableWarning
+          onInput={(e) =>
+            onChange({ ...content, text: e.currentTarget.textContent || '' })
+          }
+        >
+          {content.text}
+        </p>
+      )
+    case 'quote':
+      return (
+        <blockquote
+          key={index}
+          className="pl-6 py-4 my-6 border-l-4 border-emerald-500 bg-emerald-50 rounded-r-lg italic"
+        >
+          <p
+            contentEditable
+            suppressContentEditableWarning
+            onInput={(e) =>
+              onChange({ ...content, text: e.currentTarget.textContent || '' })
+            }
+            className="mb-2"
+          >
+            {content.text}
+          </p>
+          <p
+            className="font-medium text-emerald-700"
+            contentEditable
+            suppressContentEditableWarning
+            onInput={(e) =>
+              onChange({ ...content, author: e.currentTarget.textContent || '' })
+            }
+          >
+            {content.author}
+          </p>
+        </blockquote>
+      )
+    case 'list':
+      const handleListItemChange = (idx: number, text: string) => {
+        const items = [...content.items]
+        items[idx] = text
+        onChange({ ...content, items })
+      }
+      return (
+        <ul key={index} className="list-disc pl-6 mb-6 space-y-2">
+          {content.items.map((item, i) => (
+            <li key={i} className="text-lg">
+              <div
+                contentEditable
+                suppressContentEditableWarning
+                onInput={(e) =>
+                  handleListItemChange(i, e.currentTarget.textContent || '')
+                }
+              >
+                {item}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )
+    case 'subheading':
+      return (
+        <h3 key={index} className="text-2xl font-bold text-slate-800 mt-8 mb-4">
+          {subheadingNumber && <span className="mr-2">{subheadingNumber}</span>}
+          <span
+            contentEditable
+            suppressContentEditableWarning
+            className="border rounded p-1"
+            onInput={(e) =>
+              onChange({ ...content, text: e.currentTarget.textContent || '' })
+            }
+          >
+            {content.text}
+          </span>
+        </h3>
+      )
+    case 'bold':
+      return (
+        <strong
+          key={index}
+          className="font-semibold text-emerald-700 border rounded p-1"
+          contentEditable
+          suppressContentEditableWarning
+          onInput={(e) =>
+            onChange({ ...content, text: e.currentTarget.textContent || '' })
+          }
+        >
+          {content.text}
+        </strong>
+      )
+    case 'image':
+      return (
+        <figure
+          key={index}
+          className={`my-8 print:break-inside-avoid ${
+            content.layout === 'split' ? 'flex flex-col gap-8 items-center' : ''
+          }`}
+        >
+          <div
+            className={`relative overflow-hidden rounded-xl shadow-lg ${
+              content.layout === 'split' ? 'md:w-1/2' : ''
+            }`}
+            style={{ height: content.layout === 'split' ? '300px' : '400px' }}
+          >
+            <img
+              src={content.src}
+              alt={content.alt}
+              className="w-full h-full object-cover"
+            />
+          </div>
+          {content.caption && (
+            <figcaption
+              className={`mt-2 text-sm text-gray-600 italic ${
+                content.layout === 'split' ? 'md:w-1/2' : ''
+              }`}
+              contentEditable
+              suppressContentEditableWarning
+              onInput={(e) =>
+                onChange({ ...content, caption: e.currentTarget.textContent || '' })
+              }
+            >
+              {content.caption}
+            </figcaption>
+          )}
+        </figure>
+      )
+    default:
+      return null
+  }
+}
+
+export default EditableContentRenderer

--- a/src/components/ReportEditor.tsx
+++ b/src/components/ReportEditor.tsx
@@ -1,0 +1,101 @@
+'use client'
+import React from 'react'
+import useEditableReportData from '@/hooks/useEditableReportData'
+import { ContentItem } from '@/types/report'
+import EditableContentRenderer from './EditableContentRenderer'
+
+const ReportEditor = () => {
+  const { data, setData, save } = useEditableReportData()
+
+  if (!data) return <p>Loading...</p>
+
+  const updateMessageItem = (idx: number, value: string | ContentItem) => {
+    const newData = { ...data }
+    newData.message.content[idx] = value
+    setData(newData)
+  }
+
+  const updateSectionItem = (
+    sectionIndex: number,
+    itemIndex: number,
+    item: ContentItem
+  ) => {
+    const newData = { ...data }
+    newData.sections[sectionIndex].content[itemIndex] = item
+    setData(newData)
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto p-4 space-y-8">
+      <h1
+        className="text-2xl font-bold"
+        contentEditable
+        suppressContentEditableWarning
+        onInput={(e) => {
+          const newData = { ...data }
+          newData.reportTitle = e.currentTarget.textContent || ''
+          setData(newData)
+        }}
+      >
+        {data.reportTitle}
+      </h1>
+
+      <div className="space-y-4">
+        <h2
+          className="font-semibold text-xl"
+          contentEditable
+          suppressContentEditableWarning
+          onInput={(e) => {
+            const newData = { ...data }
+            newData.message.title = e.currentTarget.textContent || ''
+            setData(newData)
+          }}
+        >
+          {data.message.title}
+        </h2>
+        {data.message.content.map((c, i) => (
+          <EditableContentRenderer
+            key={i}
+            content={c}
+            index={i}
+            onChange={(val) => updateMessageItem(i, val)}
+          />
+        ))}
+      </div>
+
+      {data.sections.map((section, sIdx) => (
+        <div key={sIdx} className="space-y-4 border-t pt-4">
+          <div
+            className="font-semibold text-xl"
+            contentEditable
+            suppressContentEditableWarning
+            onInput={(e) => {
+              const newData = { ...data }
+              newData.sections[sIdx].title = e.currentTarget.textContent || ''
+              setData(newData)
+            }}
+          >
+            {section.title}
+          </div>
+          {section.content.map((item, cIdx) => (
+            <EditableContentRenderer
+              key={cIdx}
+              content={item as ContentItem}
+              index={cIdx}
+              onChange={(val) => updateSectionItem(sIdx, cIdx, val as ContentItem)}
+            />
+          ))}
+        </div>
+      ))}
+
+      <button
+        className="px-4 py-2 bg-emerald-600 text-white rounded"
+        onClick={() => save(data)}
+      >
+        Save
+      </button>
+    </div>
+  )
+}
+
+export default ReportEditor

--- a/src/hooks/useEditableReportData.ts
+++ b/src/hooks/useEditableReportData.ts
@@ -1,0 +1,28 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { ReportData } from '@/types/report'
+import { db, REPORT_ID } from '@/utils/db'
+
+// Hook that loads report data from Dexie and allows saving updates
+const useEditableReportData = () => {
+  const [data, setData] = useState<ReportData | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      const existing = await db.table('report').get(REPORT_ID)
+      if (existing) {
+        setData(existing as ReportData)
+      }
+    }
+    load()
+  }, [])
+
+  const save = async (newData: ReportData) => {
+    await db.table('report').put({ ...(newData as ReportData), id: REPORT_ID })
+    setData(newData)
+  }
+
+  return { data, setData, save }
+}
+
+export default useEditableReportData


### PR DESCRIPTION
## Summary
- add `EditToggle` component to switch between view and edit mode
- include floating toggle in `RootLayout`
- simplify report editor by replacing inputs with HTML `contentEditable`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f37a6cc788321b9c8f73f1cddfc64