### PR TITLE
Add faint background circles

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Inter } from "next/font/google";
 import "./globals.css";
 import SettingsFloat from "@/components/SettingsFloat";
+import BackgroundCircles from "@/components/BackgroundCircles";
 
 
 const inter = Inter({ subsets: ['latin'] });
@@ -20,6 +21,7 @@ export default function RootLayout({
       <body
         className={inter.className}
       >
+        <BackgroundCircles count={6} />
         {children}
         <SettingsFloat />
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,9 +18,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={inter.className}
-      >
+        <body
+          className={`${inter.className} relative`}
+        >
         <BackgroundCircles count={6} />
         {children}
         <SettingsFloat />

--- a/src/components/BackgroundCircles.tsx
+++ b/src/components/BackgroundCircles.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useMemo } from 'react'
+import { useEffect, useState } from 'react'
 
 const COLORS = ['#a7f3d0', '#fde68a', '#ddd6fe']
 
@@ -15,13 +15,16 @@ interface Props {
 }
 
 const BackgroundCircles = ({ count = 5 }: Props) => {
-  const circles = useMemo<Circle[]>(() => {
-    return Array.from({ length: count }).map(() => ({
+  const [circles, setCircles] = useState<Circle[]>([])
+
+  useEffect(() => {
+    const randomCircles = Array.from({ length: count }).map(() => ({
       top: Math.random() * 100,
       left: Math.random() * 100,
       size: 150 + Math.random() * 150,
       color: COLORS[Math.floor(Math.random() * COLORS.length)],
     }))
+    setCircles(randomCircles)
   }, [count])
 
   return (

--- a/src/components/BackgroundCircles.tsx
+++ b/src/components/BackgroundCircles.tsx
@@ -25,7 +25,7 @@ const BackgroundCircles = ({ count = 5 }: Props) => {
   }, [count])
 
   return (
-    <div className="absolute inset-0 pointer-events-none -z-10 print:hidden">
+    <div className="fixed inset-0 pointer-events-none z-0 print:hidden">
       {circles.map((circle, i) => (
         <div
           key={i}

--- a/src/components/BackgroundCircles.tsx
+++ b/src/components/BackgroundCircles.tsx
@@ -1,0 +1,50 @@
+'use client'
+import { useMemo } from 'react'
+
+const COLORS = ['#a7f3d0', '#fde68a', '#ddd6fe']
+
+interface Circle {
+  top: number
+  left: number
+  size: number
+  color: string
+}
+
+interface Props {
+  count?: number
+}
+
+const BackgroundCircles = ({ count = 5 }: Props) => {
+  const circles = useMemo<Circle[]>(() => {
+    return Array.from({ length: count }).map(() => ({
+      top: Math.random() * 100,
+      left: Math.random() * 100,
+      size: 150 + Math.random() * 150,
+      color: COLORS[Math.floor(Math.random() * COLORS.length)],
+    }))
+  }, [count])
+
+  return (
+    <div className="absolute inset-0 pointer-events-none -z-10 print:hidden">
+      {circles.map((circle, i) => (
+        <div
+          key={i}
+          className="rounded-full"
+          style={{
+            position: 'absolute',
+            top: `${circle.top}%`,
+            left: `${circle.left}%`,
+            width: circle.size,
+            height: circle.size,
+            backgroundColor: circle.color,
+            opacity: 0.15,
+            transform: 'translate(-50%, -50%)',
+            filter: 'blur(30px)',
+          }}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default BackgroundCircles


### PR DESCRIPTION
## Summary
- create `BackgroundCircles` component that renders random faint circles
- include this background in the app layout

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f4ff4dfa88321966a55286c9906c7