### PR TITLE
Add infographic highlights and timeline sections

### DIFF
--- a/src/components/HighlightsSection.tsx
+++ b/src/components/HighlightsSection.tsx
@@ -1,0 +1,36 @@
+'use client'
+import useReportData from '@/hooks/useReportData'
+import HeadingNumber from './HeadingNumber'
+import * as Icons from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+
+interface Props { number: number }
+
+const HighlightsSection = ({ number }: Props) => {
+  const data = useReportData()
+  if (!data || !data.highlights) return null
+  return (
+    <div id="highlights" className="mb-20 scroll-mt-20 print:break-before">
+      <h2 className="text-3xl font-bold text-slate-800 mb-10 flex items-baseline">
+        <HeadingNumber number={number} />
+        Key Highlights
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8">
+        {data.highlights.map((item, idx) => {
+          const Icon = (Icons as unknown as Record<string, LucideIcon>)[item.icon || 'Star']
+          return (
+            <div key={idx} className="text-center p-6 bg-gradient-to-br from-emerald-50 to-amber-50 rounded-xl shadow border border-emerald-100">
+              <div className="flex justify-center mb-4">
+                {Icon && <Icon className="text-emerald-600" size={36} />}
+              </div>
+              <p className="text-4xl font-extrabold text-emerald-700 mb-2">{item.value}</p>
+              <p className="text-lg text-slate-700 font-medium">{item.label}</p>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default HighlightsSection

--- a/src/components/ReportViewer.tsx
+++ b/src/components/ReportViewer.tsx
@@ -6,6 +6,8 @@ import CoverPage from './CoverPage';
 import TableOfContents from './TableOfContents';
 import MessageSection from './MessageSection';
 import ImpactSection from './ImpactSection';
+import HighlightsSection from './HighlightsSection';
+import TimelineSection from './TimelineSection';
 import StrategicVisionSection from './StrategicVisionSection';
 import Sections from './Sections';
 import FutureGoalsSection from './FutureGoalsSection';
@@ -44,6 +46,8 @@ const ReportViewer = () => {
   const tocItems = [
     { id: 'message', title: reportData.message.title },
     { id: 'impact', title: 'Our Impact at a Glance' },
+    { id: 'highlights', title: 'Key Highlights' },
+    { id: 'timeline', title: 'Progress Timeline' },
     { id: 'vision', title: 'Our Strategic Vision' },
     ...reportData.sections.map((section, i) => ({
       id: `section-${i + 1}`,
@@ -70,6 +74,8 @@ const ReportViewer = () => {
         />
         <MessageSection number={sectionNumbers['message']} />
         <ImpactSection number={sectionNumbers['impact']} />
+        <HighlightsSection number={sectionNumbers['highlights']} />
+        <TimelineSection number={sectionNumbers['timeline']} />
         <StrategicVisionSection number={sectionNumbers['vision']} />
         <Sections startNumber={sectionNumbers['section-1']} />
         <FutureGoalsSection number={sectionNumbers['future']} />

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -1,0 +1,39 @@
+'use client'
+import useReportData from '@/hooks/useReportData'
+import HeadingNumber from './HeadingNumber'
+
+interface Props { number: number }
+
+const TimelineSection = ({ number }: Props) => {
+  const data = useReportData()
+  if (!data) return null
+  return (
+    <div id="timeline" className="mb-20 scroll-mt-20 print:break-before">
+      <h2 className="text-3xl font-bold text-slate-800 mb-10 flex items-baseline">
+        <HeadingNumber number={number} />
+        Progress Timeline
+      </h2>
+      <div className="relative ml-6">
+        <div className="absolute left-5 top-0 bottom-0 w-0.5 bg-emerald-200"></div>
+        {data.milestones.map((m, idx) => (
+          <div key={idx} className="mb-8 flex items-start">
+            <div className="flex flex-col items-center mr-6">
+              <div className="w-10 h-10 rounded-full bg-emerald-500 text-white flex items-center justify-center font-bold">
+                {idx + 1}
+              </div>
+              {idx < data.milestones.length - 1 && (
+                <div className="flex-1 w-px bg-emerald-200"></div>
+              )}
+            </div>
+            <div>
+              <h3 className="font-bold text-emerald-700 mb-1">{m.title}</h3>
+              <p className="text-slate-700">{m.description}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default TimelineSection

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -14,15 +14,15 @@ const TimelineSection = ({ number }: Props) => {
         Progress Timeline
       </h2>
       <div className="relative ml-6">
-        <div className="absolute left-5 top-0 bottom-0 w-0.5 bg-emerald-200"></div>
+        <div className="absolute left-5 top-5 bottom-5 w-0.5 bg-emerald-500 z-0"></div>
         {data.milestones.map((m, idx) => (
           <div key={idx} className="mb-8 flex items-start">
-            <div className="flex flex-col items-center mr-6">
-              <div className="w-10 h-10 rounded-full bg-emerald-500 text-white flex items-center justify-center font-bold">
+            <div className="flex flex-col items-center mr-6 relative z-10">
+              <div className="w-10 h-10 rounded-full border-2 border-emerald-500 text-emerald-700 bg-white flex items-center justify-center font-bold">
                 {idx + 1}
               </div>
               {idx < data.milestones.length - 1 && (
-                <div className="flex-1 w-px bg-emerald-200"></div>
+                <div className="flex-1 w-0.5 bg-emerald-500"></div>
               )}
             </div>
             <div>

--- a/src/data/report.ts
+++ b/src/data/report.ts
@@ -51,6 +51,14 @@ export const reportData: ReportData = {
       description: "including a fuel-saver vehicle for local travel, two significant stationery donations, and laboratory equipment from OSU."
     }
   ],
+  highlights: [
+    { label: 'New Female Students', value: 10, icon: 'UserPlus' },
+    { label: 'Boreholes Drilled', value: 3, icon: 'Droplet' },
+    { label: 'Science Labs Launched', value: 2, icon: 'FlaskConical' },
+    { label: 'Women Employed', value: 15, icon: 'Users' },
+    { label: 'Partner Students on Tour', value: 20, icon: 'Globe' },
+    { label: 'Classrooms Built', value: 1, icon: 'Building2' }
+  ],
   strategicVision: {
     intro: "TTI's common goal is to provide universal access to quality education and develop an educational system that is sustainable and not solely reliant on external funding. To accomplish this, our work is guided by six core goals:",
     educationGoals: [

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -34,6 +34,12 @@ export interface MapLocation {
   lng: number
 }
 
+export interface HighlightStat {
+  label: string
+  value: number
+  icon?: string
+}
+
 export interface ReportData {
   organization: string;
   reportTitle: string;
@@ -50,6 +56,7 @@ export interface ReportData {
     educationGoals: CoreGoal[];
     businessGoals: CoreGoal[];
   };
+  highlights?: HighlightStat[];
   sections: Section[];
   futureGoals: string[];
   locations: MapLocation[]


### PR DESCRIPTION
## Summary
- add `HighlightStat` model and sample stats
- display key highlights in a new section with icons
- show milestones on a progress timeline
- include new sections in the table of contents

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f599ff22883218e5591d43b0db548