### PR TITLE
Add financials section and table styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,6 +25,23 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+/* Stylish tables used for financial data */
+.financial-table {
+  @apply w-full text-left border-collapse rounded-xl overflow-hidden shadow;
+}
+
+.financial-table th {
+  @apply bg-emerald-600 text-white font-semibold px-4 py-2;
+}
+
+.financial-table td {
+  @apply px-4 py-2 border-b border-emerald-100;
+}
+
+.financial-table tbody tr:nth-child(even) {
+  @apply bg-emerald-50;
+}
+
 @media print {
   @page {
     margin: 0.5cm;

--- a/src/components/FinancialsSection.tsx
+++ b/src/components/FinancialsSection.tsx
@@ -1,0 +1,42 @@
+'use client'
+import useReportData from '@/hooks/useReportData'
+import HeadingNumber from './HeadingNumber'
+
+interface Props {
+  number: number
+}
+
+const FinancialsSection = ({ number }: Props) => {
+  const data = useReportData()
+  if (!data || !data.financials) return null
+
+  return (
+    <div id="financials" className="mb-20 scroll-mt-20 print:break-before">
+      <h2 className="text-3xl font-bold text-slate-800 mb-10 flex items-baseline">
+        <HeadingNumber number={number} />
+        Financials
+      </h2>
+      <div className="overflow-x-auto">
+        <table className="financial-table">
+          <thead>
+            <tr>
+              <th>Item</th>
+              <th>Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.financials.map((fin, idx) => (
+              <tr key={idx}>
+                <td>{fin.item}</td>
+                <td>{fin.amount}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+export default FinancialsSection
+

--- a/src/components/ReportViewer.tsx
+++ b/src/components/ReportViewer.tsx
@@ -10,6 +10,7 @@ import HighlightsSection from './HighlightsSection';
 import TimelineSection from './TimelineSection';
 import StrategicVisionSection from './StrategicVisionSection';
 import Sections from './Sections';
+import FinancialsSection from './FinancialsSection';
 import FutureGoalsSection from './FutureGoalsSection';
 import dynamic from 'next/dynamic';
 const MapSection = dynamic(() => import('./MapSection'), { ssr: false });
@@ -53,6 +54,7 @@ const ReportViewer = () => {
       id: `section-${i + 1}`,
       title: section.title,
     })),
+    { id: 'financials', title: 'Financials' },
     { id: 'future', title: 'Looking Ahead' },
     { id: 'locations', title: 'Where We Work' },
     { id: 'thankyou', title: 'Thank You' },
@@ -78,6 +80,7 @@ const ReportViewer = () => {
         <TimelineSection number={sectionNumbers['timeline']} />
         <StrategicVisionSection number={sectionNumbers['vision']} />
         <Sections startNumber={sectionNumbers['section-1']} />
+        <FinancialsSection number={sectionNumbers['financials']} />
         <FutureGoalsSection number={sectionNumbers['future']} />
         <MapSection number={sectionNumbers['locations']} />
         <ClosingSection number={sectionNumbers['thankyou']} />

--- a/src/data/report.ts
+++ b/src/data/report.ts
@@ -176,6 +176,13 @@ export const reportData: ReportData = {
     "Continue construction of the Chivakanenyama Secondary School classroom block.",
     "Conduct a full financial review of all H1 2025 projects."
   ],
+  financials: [
+    { item: 'Total Donations', amount: '$35,000' },
+    { item: 'Scholarship Support', amount: '$15,000' },
+    { item: 'Infrastructure Projects', amount: '$10,000' },
+    { item: 'Community Programs', amount: '$7,000' },
+    { item: 'Administrative Costs', amount: '$3,000' }
+  ],
   locations: [
     { name: 'Chivakanenyama Secondary School', lat: -16.712, lng: 29.164 },
     { name: 'Zvimhonja Primary School', lat: -16.745, lng: 29.123 },

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -40,6 +40,11 @@ export interface HighlightStat {
   icon?: string
 }
 
+export interface FinancialEntry {
+  item: string
+  amount: string
+}
+
 export interface ReportData {
   organization: string;
   reportTitle: string;
@@ -57,6 +62,7 @@ export interface ReportData {
     businessGoals: CoreGoal[];
   };
   highlights?: HighlightStat[];
+  financials?: FinancialEntry[];
   sections: Section[];
   futureGoals: string[];
   locations: MapLocation[]


### PR DESCRIPTION
## Summary
- include financials data in `ReportData`
- style tables globally
- create `FinancialsSection` for displaying financial data
- show `FinancialsSection` in `ReportViewer`
- update sample `report` data with financial figures

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f99ebd1e88321a3ffa4159dcd7151