### PR TITLE
Enable global edit context

### DIFF
--- a/src/app/edit/page.tsx
+++ b/src/app/edit/page.tsx
@@ -1,8 +1,8 @@
 'use client'
-import ReportEditor from '@/components/ReportEditor'
+import ReportViewer from '@/components/ReportViewer'
 
 const EditPage = () => {
-  return <ReportEditor />
+  return <ReportViewer />
 }
 
 export default EditPage

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import SettingsFloat from "@/components/SettingsFloat";
 import { inter } from "@/fonts";
+import { ReportProvider } from "@/contexts/ReportContext";
 
 export const metadata = {
   title: 'TTI Foundation H1 2025 Progress Report',
@@ -14,11 +15,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={inter.className}
-      >
-        {children}
-        <SettingsFloat />
+      <body className={inter.className}>
+        <ReportProvider>
+          {children}
+          <SettingsFloat />
+        </ReportProvider>
       </body>
     </html>
   );

--- a/src/components/ClosingSection.tsx
+++ b/src/components/ClosingSection.tsx
@@ -49,6 +49,37 @@ const ClosingSection = ({ number }: Props) => {
           >
             {data.closingImage.caption}
           </p>
+          {editing && (
+            <div className="text-sm text-gray-500 text-center">
+              Src:{' '}
+              <span
+                contentEditable
+                suppressContentEditableWarning
+                onBlur={(e: React.FocusEvent<HTMLElement>) => {
+                  const newData = { ...(data as typeof data) }
+                  if (newData.closingImage)
+                    newData.closingImage.src = e.currentTarget.textContent || ''
+                  setData(newData)
+                }}
+              >
+                {data.closingImage.src}
+              </span>
+              <br />
+              Alt:{' '}
+              <span
+                contentEditable
+                suppressContentEditableWarning
+                onBlur={(e: React.FocusEvent<HTMLElement>) => {
+                  const newData = { ...(data as typeof data) }
+                  if (newData.closingImage)
+                    newData.closingImage.alt = e.currentTarget.textContent || ''
+                  setData(newData)
+                }}
+              >
+                {data.closingImage.alt}
+              </span>
+            </div>
+          )}
         </div>
       )}
       <p

--- a/src/components/ClosingSection.tsx
+++ b/src/components/ClosingSection.tsx
@@ -1,28 +1,72 @@
 'use client'
-import useReportData from '@/hooks/useReportData'
+import { useReport } from '@/contexts/ReportContext'
 import HeadingNumber from './HeadingNumber'
 
 interface Props { number: number }
 
 const ClosingSection = ({ number }: Props) => {
-  const reportData = useReportData();
-  if (!reportData) return null;
+  const { data, setData, editing } = useReport();
+  if (!data) return null;
 
   return (
     <div id="thankyou" className="text-center py-16 border-t border-emerald-100 scroll-mt-20 print:break-before">
-      <h3 className="text-3xl font-bold text-slate-800 mb-6 flex items-baseline justify-center">
+      <h3
+        className="text-3xl font-bold text-slate-800 mb-6 flex items-baseline justify-center"
+        {...(editing
+          ? {
+              contentEditable: true,
+              suppressContentEditableWarning: true,
+              onInput: (e: React.FormEvent<HTMLElement>) => {
+                const newData = { ...(data as typeof data) }
+                newData.closingTitle = e.currentTarget.textContent || ''
+                setData(newData)
+              },
+            }
+          : {})}
+      >
         <HeadingNumber number={number} />
-        A Heartfelt Thank You
+        {data.closingTitle}
       </h3>
-      {reportData.closingImage && (
+      {data.closingImage && (
         <div className="mt-12 mb-8 max-w-3xl mx-auto print:break-inside-avoid">
           <div className="relative w-full h-96 rounded-2xl overflow-hidden shadow-xl">
-            <img src={reportData.closingImage.src} alt={reportData.closingImage.alt} className="w-full h-full object-cover" />
+            <img src={data.closingImage.src} alt={data.closingImage.alt} className="w-full h-full object-cover" />
           </div>
-          <p className="text-center text-sm text-gray-600 italic mt-2">{reportData.closingImage.caption}</p>
+          <p
+            className="text-center text-sm text-gray-600 italic mt-2"
+            {...(editing
+              ? {
+                  contentEditable: true,
+                  suppressContentEditableWarning: true,
+                  onInput: (e: React.FormEvent<HTMLElement>) => {
+                    const newData = { ...(data as typeof data) }
+                    if (newData.closingImage)
+                      newData.closingImage.caption = e.currentTarget.textContent || ''
+                    setData(newData)
+                  },
+                }
+              : {})}
+          >
+            {data.closingImage.caption}
+          </p>
         </div>
       )}
-      <p className="text-xl text-slate-600 max-w-3xl mx-auto">{reportData.closing}</p>
+      <p
+        className="text-xl text-slate-600 max-w-3xl mx-auto"
+        {...(editing
+          ? {
+              contentEditable: true,
+              suppressContentEditableWarning: true,
+              onInput: (e: React.FormEvent<HTMLElement>) => {
+                const newData = { ...(data as typeof data) }
+                newData.closing = e.currentTarget.textContent || ''
+                setData(newData)
+              },
+            }
+          : {})}
+      >
+        {data.closing}
+      </p>
 
     </div>
   );

--- a/src/components/ClosingSection.tsx
+++ b/src/components/ClosingSection.tsx
@@ -16,7 +16,7 @@ const ClosingSection = ({ number }: Props) => {
           ? {
               contentEditable: true,
               suppressContentEditableWarning: true,
-              onInput: (e: React.FormEvent<HTMLElement>) => {
+              onBlur: (e: React.FocusEvent<HTMLElement>) => {
                 const newData = { ...(data as typeof data) }
                 newData.closingTitle = e.currentTarget.textContent || ''
                 setData(newData)
@@ -38,7 +38,7 @@ const ClosingSection = ({ number }: Props) => {
               ? {
                   contentEditable: true,
                   suppressContentEditableWarning: true,
-                  onInput: (e: React.FormEvent<HTMLElement>) => {
+                  onBlur: (e: React.FocusEvent<HTMLElement>) => {
                     const newData = { ...(data as typeof data) }
                     if (newData.closingImage)
                       newData.closingImage.caption = e.currentTarget.textContent || ''
@@ -57,7 +57,7 @@ const ClosingSection = ({ number }: Props) => {
           ? {
               contentEditable: true,
               suppressContentEditableWarning: true,
-              onInput: (e: React.FormEvent<HTMLElement>) => {
+              onBlur: (e: React.FocusEvent<HTMLElement>) => {
                 const newData = { ...(data as typeof data) }
                 newData.closing = e.currentTarget.textContent || ''
                 setData(newData)

--- a/src/components/ContentRenderer.tsx
+++ b/src/components/ContentRenderer.tsx
@@ -17,7 +17,7 @@ const ContentRenderer = ({ content, index, subheadingNumber, editable, onChange 
       ? {
           contentEditable: true,
           suppressContentEditableWarning: true,
-          onInput: (e: React.FormEvent<HTMLElement>) =>
+          onBlur: (e: React.FocusEvent<HTMLElement>) =>
             cb((e.currentTarget.textContent as string) || ''),
         }
       : {}

--- a/src/components/CoverPage.tsx
+++ b/src/components/CoverPage.tsx
@@ -1,9 +1,9 @@
 'use client'
-import useReportData from '@/hooks/useReportData';
+import { useReport } from '@/contexts/ReportContext';
 
 const CoverPage = () => {
-  const reportData = useReportData();
-  if (!reportData) return null;
+  const { data, setData, editing } = useReport();
+  if (!data) return null;
 
   return (
   <div className="min-h-screen flex flex-col justify-center items-center text-center py-20 mb-16 relative print:min-h-screen print:mb-0 print:py-0 print:flex print:justify-center print:items-center">
@@ -13,15 +13,57 @@ const CoverPage = () => {
     <div className="absolute top-1/3 right-20 w-16 h-16 rounded-full bg-purple-200 opacity-50"></div>
     <div className="relative z-10 px-8 py-12 max-w-3xl mx-auto bg-transparent shadow-none">
       <div className="bg-emerald-100 p-2 px-4 rounded-full mb-8 inline-block">
-        <p className="text-emerald-700 font-sans font-bold">Progress Report • {reportData.period}</p>
+        <p
+          className="text-emerald-700 font-sans font-bold"
+          {...(editing
+            ? {
+                contentEditable: true,
+                suppressContentEditableWarning: true,
+                onInput: (e: React.FormEvent<HTMLElement>) => {
+                  const newData = { ...(data as typeof data) }
+                  newData.period = e.currentTarget.textContent || ''
+                  setData(newData)
+                },
+              }
+            : {})}
+        >
+          Progress Report • {data.period}
+        </p>
       </div>
-      <h1 className="text-5xl md:text-6xl font-bold text-slate-800 mb-6 leading-tight">
-        {reportData.reportTitle}
+      <h1
+        className="text-5xl md:text-6xl font-bold text-slate-800 mb-6 leading-tight"
+        {...(editing
+          ? {
+              contentEditable: true,
+              suppressContentEditableWarning: true,
+              onInput: (e: React.FormEvent<HTMLElement>) => {
+                const newData = { ...(data as typeof data) }
+                newData.reportTitle = e.currentTarget.textContent || ''
+                setData(newData)
+              },
+            }
+          : {})}
+      >
+        {data.reportTitle}
       </h1>
       <div className="w-32 h-1 bg-amber-500 my-8 mx-auto"></div>
-      <p className="text-2xl text-slate-600 mb-12">
-        {reportData.organization}<br />
-        {reportData.period}
+      <p
+        className="text-2xl text-slate-600 mb-12"
+        {...(editing
+          ? {
+              contentEditable: true,
+              suppressContentEditableWarning: true,
+              onInput: (e: React.FormEvent<HTMLElement>) => {
+                const newData = { ...(data as typeof data) }
+                newData.organization = e.currentTarget.textContent || ''
+                setData(newData)
+              },
+            }
+          : {})}
+      >
+        {data.organization}
+        <br />
+        {data.period}
       </p>
       <div className="relative w-64 h-64 rounded-full overflow-hidden border-8 border-emerald-100 shadow-xl mx-auto">
         <img

--- a/src/components/CoverPage.tsx
+++ b/src/components/CoverPage.tsx
@@ -19,7 +19,7 @@ const CoverPage = () => {
             ? {
                 contentEditable: true,
                 suppressContentEditableWarning: true,
-                onInput: (e: React.FormEvent<HTMLElement>) => {
+                onBlur: (e: React.FocusEvent<HTMLElement>) => {
                   const newData = { ...(data as typeof data) }
                   newData.period = e.currentTarget.textContent || ''
                   setData(newData)
@@ -36,7 +36,7 @@ const CoverPage = () => {
           ? {
               contentEditable: true,
               suppressContentEditableWarning: true,
-              onInput: (e: React.FormEvent<HTMLElement>) => {
+              onBlur: (e: React.FocusEvent<HTMLElement>) => {
                 const newData = { ...(data as typeof data) }
                 newData.reportTitle = e.currentTarget.textContent || ''
                 setData(newData)
@@ -53,7 +53,7 @@ const CoverPage = () => {
           ? {
               contentEditable: true,
               suppressContentEditableWarning: true,
-              onInput: (e: React.FormEvent<HTMLElement>) => {
+              onBlur: (e: React.FocusEvent<HTMLElement>) => {
                 const newData = { ...(data as typeof data) }
                 newData.organization = e.currentTarget.textContent || ''
                 setData(newData)

--- a/src/components/FutureGoalsSection.tsx
+++ b/src/components/FutureGoalsSection.tsx
@@ -1,26 +1,54 @@
 'use client'
-import useReportData from '@/hooks/useReportData'
+import { useReport } from '@/contexts/ReportContext'
 import HeadingNumber from './HeadingNumber'
 
 interface Props { number: number }
 
 const FutureGoalsSection = ({ number }: Props) => {
-  const reportData = useReportData();
-  if (!reportData) return null;
+  const { data, setData, editing } = useReport();
+  if (!data) return null;
 
   return (
   <div id="future" className="mb-20 scroll-mt-20 print:break-before">
-    <h2 className="text-3xl font-bold text-slate-800 mb-10 flex items-baseline">
+    <h2
+      className="text-3xl font-bold text-slate-800 mb-10 flex items-baseline"
+      {...(editing
+        ? {
+            contentEditable: true,
+            suppressContentEditableWarning: true,
+            onInput: (e: React.FormEvent<HTMLElement>) => {
+              const newData = { ...(data as typeof data) }
+              newData.futureGoalsTitle = e.currentTarget.textContent || ''
+              setData(newData)
+            },
+          }
+        : {})}
+    >
       <HeadingNumber number={number} />
-      Looking Ahead: Our Goals for H2 2025
+      {data.futureGoalsTitle}
     </h2>
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-      {reportData.futureGoals.map((goal, index) => (
+      {data.futureGoals.map((goal, index) => (
         <div key={index} className="flex items-start bg-gradient-to-br from-emerald-50 to-white p-6 rounded-xl border border-emerald-100">
           <div className="bg-emerald-500 text-white rounded-full h-8 w-8 flex items-center justify-center mr-4 mt-1 flex-shrink-0">
             {index + 1}
           </div>
-          <p className="font-medium">{goal}</p>
+          <p
+            className="font-medium"
+            {...(editing
+              ? {
+                  contentEditable: true,
+                  suppressContentEditableWarning: true,
+                  onInput: (e: React.FormEvent<HTMLElement>) => {
+                    const newData = { ...(data as typeof data) }
+                    newData.futureGoals[index] = e.currentTarget.textContent || ''
+                    setData(newData)
+                  },
+                }
+              : {})}
+          >
+            {goal}
+          </p>
         </div>
       ))}
     </div>

--- a/src/components/FutureGoalsSection.tsx
+++ b/src/components/FutureGoalsSection.tsx
@@ -52,14 +52,69 @@ const FutureGoalsSection = ({ number }: Props) => {
         </div>
       ))}
     </div>
-    <div className="mt-12 print:break-inside-avoid">
-      <div className="relative w-full h-80 rounded-2xl overflow-hidden shadow-xl">
-        <img src="https://images.unsplash.com/photo-1523580494863-6f3031224c94" alt="Future vision" className="w-full h-full object-cover" />
+    {data.futureVisionImage && (
+      <div className="mt-12 print:break-inside-avoid">
+        <div className="relative w-full h-80 rounded-2xl overflow-hidden shadow-xl">
+          <img src={data.futureVisionImage.src} alt={data.futureVisionImage.alt} className="w-full h-full object-cover" />
+        </div>
+        <p
+          className="text-center text-sm text-gray-600 italic mt-2"
+          {...(editing
+            ? {
+                contentEditable: true,
+                suppressContentEditableWarning: true,
+                onBlur: (e: React.FocusEvent<HTMLElement>) => {
+                  const newData = { ...(data as typeof data) }
+                  if (newData.futureVisionImage)
+                    newData.futureVisionImage.caption = e.currentTarget.textContent || ''
+                  setData(newData)
+                },
+              }
+            : {})}
+        >
+          {data.futureVisionImage.caption}
+        </p>
+        {editing && (
+          <div className="text-sm text-gray-500 text-center">
+            Src:{' '}
+            <span
+              {...(editing
+                ? {
+                    contentEditable: true,
+                    suppressContentEditableWarning: true,
+                    onBlur: (e: React.FocusEvent<HTMLElement>) => {
+                      const newData = { ...(data as typeof data) }
+                      if (newData.futureVisionImage)
+                        newData.futureVisionImage.src = e.currentTarget.textContent || ''
+                      setData(newData)
+                    },
+                  }
+                : {})}
+            >
+              {data.futureVisionImage.src}
+            </span>
+            <br />
+            Alt:{' '}
+            <span
+              {...(editing
+                ? {
+                    contentEditable: true,
+                    suppressContentEditableWarning: true,
+                    onBlur: (e: React.FocusEvent<HTMLElement>) => {
+                      const newData = { ...(data as typeof data) }
+                      if (newData.futureVisionImage)
+                        newData.futureVisionImage.alt = e.currentTarget.textContent || ''
+                      setData(newData)
+                    },
+                  }
+                : {})}
+            >
+              {data.futureVisionImage.alt}
+            </span>
+          </div>
+        )}
       </div>
-      <p className="text-center text-sm text-gray-600 italic mt-2">
-        Vision for the new Library and Computer Lab at Musukwi Secondary
-      </p>
-    </div>
+    )}
   </div>
   );
 }

--- a/src/components/FutureGoalsSection.tsx
+++ b/src/components/FutureGoalsSection.tsx
@@ -16,7 +16,7 @@ const FutureGoalsSection = ({ number }: Props) => {
         ? {
             contentEditable: true,
             suppressContentEditableWarning: true,
-            onInput: (e: React.FormEvent<HTMLElement>) => {
+            onBlur: (e: React.FocusEvent<HTMLElement>) => {
               const newData = { ...(data as typeof data) }
               newData.futureGoalsTitle = e.currentTarget.textContent || ''
               setData(newData)
@@ -39,7 +39,7 @@ const FutureGoalsSection = ({ number }: Props) => {
               ? {
                   contentEditable: true,
                   suppressContentEditableWarning: true,
-                  onInput: (e: React.FormEvent<HTMLElement>) => {
+                  onBlur: (e: React.FocusEvent<HTMLElement>) => {
                     const newData = { ...(data as typeof data) }
                     newData.futureGoals[index] = e.currentTarget.textContent || ''
                     setData(newData)

--- a/src/components/GuidingMission.tsx
+++ b/src/components/GuidingMission.tsx
@@ -1,14 +1,44 @@
 'use client'
-import useReportData from '@/hooks/useReportData'
+import { useReport } from '@/contexts/ReportContext'
 
 const GuidingMission = () => {
-  const reportData = useReportData();
-  if (!reportData) return null;
+  const { data, setData, editing } = useReport();
+  if (!data) return null;
 
   return (
   <div className="mb-16 text-center p-6 bg-gradient-to-r from-emerald-50 to-amber-50 rounded-xl print:break-before">
-    <p className="text-xl italic text-emerald-700 mb-6">“{reportData.guidingPrinciple}”</p>
-    <p className="text-lg text-slate-700">{reportData.mission}</p>
+    <p
+      className="text-xl italic text-emerald-700 mb-6"
+      {...(editing
+        ? {
+            contentEditable: true,
+            suppressContentEditableWarning: true,
+            onBlur: (e: React.FocusEvent<HTMLElement>) => {
+              const newData = { ...(data as typeof data) };
+              newData.guidingPrinciple = e.currentTarget.textContent || '';
+              setData(newData);
+            },
+          }
+        : {})}
+    >
+      “{data.guidingPrinciple}”
+    </p>
+    <p
+      className="text-lg text-slate-700"
+      {...(editing
+        ? {
+            contentEditable: true,
+            suppressContentEditableWarning: true,
+            onBlur: (e: React.FocusEvent<HTMLElement>) => {
+              const newData = { ...(data as typeof data) };
+              newData.mission = e.currentTarget.textContent || '';
+              setData(newData);
+            },
+          }
+        : {})}
+    >
+      {data.mission}
+    </p>
   </div>
   );
 }

--- a/src/components/HighlightsSection.tsx
+++ b/src/components/HighlightsSection.tsx
@@ -17,7 +17,7 @@ const HighlightsSection = ({ number }: Props) => {
           ? {
               contentEditable: true,
               suppressContentEditableWarning: true,
-              onInput: (e: React.FormEvent<HTMLElement>) => {
+              onBlur: (e: React.FocusEvent<HTMLElement>) => {
                 const newData = { ...(data as typeof data) }
                 newData.highlightsTitle = e.currentTarget.textContent || ''
                 setData(newData)
@@ -42,7 +42,7 @@ const HighlightsSection = ({ number }: Props) => {
                   ? {
                       contentEditable: true,
                       suppressContentEditableWarning: true,
-                      onInput: (e: React.FormEvent<HTMLElement>) => {
+                      onBlur: (e: React.FocusEvent<HTMLElement>) => {
                         const newData = { ...(data as typeof data) }
                         if (newData.highlights)
                           newData.highlights[idx].value = Number(e.currentTarget.textContent) || 0
@@ -59,7 +59,7 @@ const HighlightsSection = ({ number }: Props) => {
                   ? {
                       contentEditable: true,
                       suppressContentEditableWarning: true,
-                      onInput: (e: React.FormEvent<HTMLElement>) => {
+                      onBlur: (e: React.FocusEvent<HTMLElement>) => {
                         const newData = { ...(data as typeof data) }
                         if (newData.highlights)
                           newData.highlights[idx].label = e.currentTarget.textContent || ''

--- a/src/components/HighlightsSection.tsx
+++ b/src/components/HighlightsSection.tsx
@@ -1,5 +1,5 @@
 'use client'
-import useReportData from '@/hooks/useReportData'
+import { useReport } from '@/contexts/ReportContext'
 import HeadingNumber from './HeadingNumber'
 import * as Icons from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
@@ -7,13 +7,26 @@ import type { LucideIcon } from 'lucide-react'
 interface Props { number: number }
 
 const HighlightsSection = ({ number }: Props) => {
-  const data = useReportData()
+  const { data, setData, editing } = useReport()
   if (!data || !data.highlights) return null
   return (
     <div id="highlights" className="mb-20 scroll-mt-20 print:break-before">
-      <h2 className="text-3xl font-bold text-slate-800 mb-10 flex items-baseline">
+      <h2
+        className="text-3xl font-bold text-slate-800 mb-10 flex items-baseline"
+        {...(editing
+          ? {
+              contentEditable: true,
+              suppressContentEditableWarning: true,
+              onInput: (e: React.FormEvent<HTMLElement>) => {
+                const newData = { ...(data as typeof data) }
+                newData.highlightsTitle = e.currentTarget.textContent || ''
+                setData(newData)
+              },
+            }
+          : {})}
+      >
         <HeadingNumber number={number} />
-        Key Highlights
+        {data.highlightsTitle}
       </h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8">
         {data.highlights.map((item, idx) => {
@@ -23,8 +36,40 @@ const HighlightsSection = ({ number }: Props) => {
               <div className="flex justify-center mb-4">
                 {Icon && <Icon className="text-emerald-600" size={36} />}
               </div>
-              <p className="text-4xl font-extrabold text-emerald-700 mb-2">{item.value}</p>
-              <p className="text-lg text-slate-700 font-medium">{item.label}</p>
+              <p
+                className="text-4xl font-extrabold text-emerald-700 mb-2"
+                {...(editing
+                  ? {
+                      contentEditable: true,
+                      suppressContentEditableWarning: true,
+                      onInput: (e: React.FormEvent<HTMLElement>) => {
+                        const newData = { ...(data as typeof data) }
+                        if (newData.highlights)
+                          newData.highlights[idx].value = Number(e.currentTarget.textContent) || 0
+                        setData(newData)
+                      },
+                    }
+                  : {})}
+              >
+                {item.value}
+              </p>
+              <p
+                className="text-lg text-slate-700 font-medium"
+                {...(editing
+                  ? {
+                      contentEditable: true,
+                      suppressContentEditableWarning: true,
+                      onInput: (e: React.FormEvent<HTMLElement>) => {
+                        const newData = { ...(data as typeof data) }
+                        if (newData.highlights)
+                          newData.highlights[idx].label = e.currentTarget.textContent || ''
+                        setData(newData)
+                      },
+                    }
+                  : {})}
+              >
+                {item.label}
+              </p>
             </div>
           )
         })}

--- a/src/components/ImpactSection.tsx
+++ b/src/components/ImpactSection.tsx
@@ -1,28 +1,73 @@
 'use client'
-import useReportData from '@/hooks/useReportData'
+import { useReport } from '@/contexts/ReportContext'
 import HeadingNumber from './HeadingNumber'
 
 interface Props { number: number }
 
 const ImpactSection = ({ number }: Props) => {
-  const reportData = useReportData();
-  if (!reportData) return null;
+  const { data, setData, editing } = useReport();
+  if (!data) return null;
 
   return (
   <div id="impact" className="mb-20 scroll-mt-20 print:break-before">
-    <h2 className="text-3xl font-bold text-slate-800 mb-10 flex items-baseline">
+    <h2
+      className="text-3xl font-bold text-slate-800 mb-10 flex items-baseline"
+      {...(editing
+        ? {
+            contentEditable: true,
+            suppressContentEditableWarning: true,
+            onInput: (e: React.FormEvent<HTMLElement>) => {
+              const newData = { ...(data as typeof data) }
+              newData.impactTitle = e.currentTarget.textContent || ''
+              setData(newData)
+            },
+          }
+        : {})}
+    >
       <HeadingNumber number={number} />
-      Our Impact at a Glance
+      {data.impactTitle}
     </h2>
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-      {reportData.milestones.map((milestone, index) => (
+      {data.milestones.map((milestone, index) => (
         <div key={index} className="flex items-start p-6 bg-gradient-to-br from-emerald-50 to-amber-50 rounded-xl border border-emerald-100">
           <div className="bg-emerald-500 text-white rounded-full h-8 w-8 flex items-center justify-center mr-4 mt-1 flex-shrink-0">
             {index + 1}
           </div>
           <div>
-            <h3 className="text-xl font-bold text-emerald-700">{milestone.title}</h3>
-            <p className="text-slate-700">{milestone.description}</p>
+            <h3
+              className="text-xl font-bold text-emerald-700"
+              {...(editing
+                ? {
+                    contentEditable: true,
+                    suppressContentEditableWarning: true,
+                    onInput: (e: React.FormEvent<HTMLElement>) => {
+                      const newData = { ...(data as typeof data) }
+                      newData.milestones[index].title =
+                        e.currentTarget.textContent || ''
+                      setData(newData)
+                    },
+                  }
+                : {})}
+            >
+              {milestone.title}
+            </h3>
+            <p
+              className="text-slate-700"
+              {...(editing
+                ? {
+                    contentEditable: true,
+                    suppressContentEditableWarning: true,
+                    onInput: (e: React.FormEvent<HTMLElement>) => {
+                      const newData = { ...(data as typeof data) }
+                      newData.milestones[index].description =
+                        e.currentTarget.textContent || ''
+                      setData(newData)
+                    },
+                  }
+                : {})}
+            >
+              {milestone.description}
+            </p>
           </div>
         </div>
       ))}

--- a/src/components/ImpactSection.tsx
+++ b/src/components/ImpactSection.tsx
@@ -16,7 +16,7 @@ const ImpactSection = ({ number }: Props) => {
         ? {
             contentEditable: true,
             suppressContentEditableWarning: true,
-            onInput: (e: React.FormEvent<HTMLElement>) => {
+            onBlur: (e: React.FocusEvent<HTMLElement>) => {
               const newData = { ...(data as typeof data) }
               newData.impactTitle = e.currentTarget.textContent || ''
               setData(newData)
@@ -40,7 +40,7 @@ const ImpactSection = ({ number }: Props) => {
                 ? {
                     contentEditable: true,
                     suppressContentEditableWarning: true,
-                    onInput: (e: React.FormEvent<HTMLElement>) => {
+                    onBlur: (e: React.FocusEvent<HTMLElement>) => {
                       const newData = { ...(data as typeof data) }
                       newData.milestones[index].title =
                         e.currentTarget.textContent || ''
@@ -57,7 +57,7 @@ const ImpactSection = ({ number }: Props) => {
                 ? {
                     contentEditable: true,
                     suppressContentEditableWarning: true,
-                    onInput: (e: React.FormEvent<HTMLElement>) => {
+                    onBlur: (e: React.FocusEvent<HTMLElement>) => {
                       const newData = { ...(data as typeof data) }
                       newData.milestones[index].description =
                         e.currentTarget.textContent || ''

--- a/src/components/MapSection.tsx
+++ b/src/components/MapSection.tsx
@@ -35,7 +35,7 @@ const MapSection = ({ number }: Props) => {
           ? {
               contentEditable: true,
               suppressContentEditableWarning: true,
-              onInput: (e: React.FormEvent<HTMLElement>) => {
+              onBlur: (e: React.FocusEvent<HTMLElement>) => {
                 const newData = { ...(data as typeof data) }
                 newData.locationsTitle = e.currentTarget.textContent || ''
                 setData(newData)

--- a/src/components/MapSection.tsx
+++ b/src/components/MapSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
 import 'leaflet/dist/leaflet.css'
-import useReportData from '@/hooks/useReportData'
+import { useReport } from '@/contexts/ReportContext'
 import L from 'leaflet'
 import { useEffect } from 'react'
 import HeadingNumber from './HeadingNumber'
@@ -9,7 +9,7 @@ import HeadingNumber from './HeadingNumber'
 interface Props { number: number }
 
 const MapSection = ({ number }: Props) => {
-  const data = useReportData()
+  const { data, setData, editing } = useReport()
 
   useEffect(() => {
     if (!data) return
@@ -29,9 +29,22 @@ const MapSection = ({ number }: Props) => {
 
   return (
     <div id="locations" className="mb-20 scroll-mt-20 print:break-before">
-      <h2 className="text-3xl font-bold text-slate-800 mb-10 flex items-baseline">
+      <h2
+        className="text-3xl font-bold text-slate-800 mb-10 flex items-baseline"
+        {...(editing
+          ? {
+              contentEditable: true,
+              suppressContentEditableWarning: true,
+              onInput: (e: React.FormEvent<HTMLElement>) => {
+                const newData = { ...(data as typeof data) }
+                newData.locationsTitle = e.currentTarget.textContent || ''
+                setData(newData)
+              },
+            }
+          : {})}
+      >
         <HeadingNumber number={number} />
-        Where We Work
+        {data.locationsTitle}
       </h2>
       <div className="w-full h-96 rounded-xl overflow-hidden shadow-xl">
         <MapContainer center={center} zoom={9} className="h-full w-full">

--- a/src/components/MessageSection.tsx
+++ b/src/components/MessageSection.tsx
@@ -20,7 +20,7 @@ const MessageSection = ({ number }: Props) => {
         ? {
             contentEditable: true,
             suppressContentEditableWarning: true,
-            onInput: (e: React.FormEvent<HTMLElement>) => {
+            onBlur: (e: React.FocusEvent<HTMLElement>) => {
               const newData = { ...(data as ReportData) }
               newData.message.title = e.currentTarget.textContent || ''
               setData(newData)

--- a/src/components/MessageSection.tsx
+++ b/src/components/MessageSection.tsx
@@ -1,6 +1,7 @@
 'use client'
 import ContentRenderer from './ContentRenderer'
-import useReportData from '@/hooks/useReportData'
+import { useReport } from '@/contexts/ReportContext'
+import { ReportData } from '@/types/report'
 import HeadingNumber from './HeadingNumber'
 
 interface Props {
@@ -8,17 +9,40 @@ interface Props {
 }
 
 const MessageSection = ({ number }: Props) => {
-  const reportData = useReportData();
-  if (!reportData) return null;
+  const { data, setData, editing } = useReport()
+  if (!data) return null
 
   return (
   <div id="message" className="mb-20 scroll-mt-20 print:break-before">
-    <h2 className="text-3xl font-bold text-slate-800 mb-6 flex items-baseline">
+    <h2
+      className="text-3xl font-bold text-slate-800 mb-6 flex items-baseline"
+      {...(editing
+        ? {
+            contentEditable: true,
+            suppressContentEditableWarning: true,
+            onInput: (e: React.FormEvent<HTMLElement>) => {
+              const newData = { ...(data as ReportData) }
+              newData.message.title = e.currentTarget.textContent || ''
+              setData(newData)
+            },
+          }
+        : {})}
+    >
       <HeadingNumber number={number} />
-      {reportData.message.title}
+      {data.message.title}
     </h2>
-    {reportData.message.content.map((content, index) => (
-      <ContentRenderer key={index} content={content} index={index} />
+    {data.message.content.map((content, index) => (
+      <ContentRenderer
+        key={index}
+        content={content}
+        index={index}
+        editable={editing}
+        onChange={(val) => {
+          const newData = { ...(data as ReportData) }
+          newData.message.content[index] = val
+          setData(newData)
+        }}
+      />
     ))}
   </div>
   );

--- a/src/components/ReportEditor.tsx
+++ b/src/components/ReportEditor.tsx
@@ -48,7 +48,7 @@ const ReportEditor = () => {
             className="text-3xl font-bold text-slate-800 mb-10"
             contentEditable
             suppressContentEditableWarning
-            onInput={(e) => {
+            onBlur={(e) => {
               const newData = { ...data }
               newData.sections[sIdx].title = e.currentTarget.textContent || ''
               setData(newData)

--- a/src/components/ReportEditor.tsx
+++ b/src/components/ReportEditor.tsx
@@ -73,7 +73,7 @@ const ReportEditor = () => {
       <div className="flex space-x-4">
         <button
           className="px-4 py-2 bg-emerald-600 text-white rounded"
-          onClick={() => save(data)}
+          onClick={() => save()}
         >
           Save
         </button>

--- a/src/components/Sections.tsx
+++ b/src/components/Sections.tsx
@@ -26,7 +26,7 @@ const Sections = ({ startNumber }: Props) => {
                 ? {
                     contentEditable: true,
                     suppressContentEditableWarning: true,
-                    onInput: (e: React.FormEvent<HTMLElement>) => {
+                    onBlur: (e: React.FocusEvent<HTMLElement>) => {
                       const newData = { ...(data as ReportData) }
                       newData.sections[sectionIndex].title =
                         e.currentTarget.textContent || ''

--- a/src/components/Sections.tsx
+++ b/src/components/Sections.tsx
@@ -1,19 +1,19 @@
 'use client'
-import useReportData from '@/hooks/useReportData'
+import { useReport } from '@/contexts/ReportContext'
 import ContentRenderer from './ContentRenderer'
-import { ContentItem } from '@/types/report'
+import { ContentItem, ReportData } from '@/types/report'
 import HeadingNumber from './HeadingNumber'
 interface Props {
   startNumber: number
 }
 
 const Sections = ({ startNumber }: Props) => {
-  const reportData = useReportData();
-  if (!reportData) return null;
+  const { data, setData, editing } = useReport()
+  if (!data) return null
 
   return (
   <>
-    {reportData.sections.map((section, sectionIndex) => {
+    {data.sections.map((section, sectionIndex) => {
       const sectionNumber = startNumber + sectionIndex
       const sectionId = `section-${sectionIndex + 1}`
       let subIndex = 0
@@ -21,7 +21,22 @@ const Sections = ({ startNumber }: Props) => {
         <div key={sectionIndex} id={sectionId} className="mb-20 scroll-mt-20 print:break-before">
           <h2 className="text-3xl font-bold text-slate-800 mb-10 flex items-baseline">
             <HeadingNumber number={sectionNumber} />
-            {section.title}
+            <span
+              {...(editing
+                ? {
+                    contentEditable: true,
+                    suppressContentEditableWarning: true,
+                    onInput: (e: React.FormEvent<HTMLElement>) => {
+                      const newData = { ...(data as ReportData) }
+                      newData.sections[sectionIndex].title =
+                        e.currentTarget.textContent || ''
+                      setData(newData)
+                    },
+                  }
+                : {})}
+            >
+              {section.title}
+            </span>
           </h2>
           <div className="space-y-6">
             {section.content.map((content, contentIndex) => {
@@ -36,6 +51,13 @@ const Sections = ({ startNumber }: Props) => {
                   content={content}
                   index={contentIndex}
                   subheadingNumber={subNumber}
+                  editable={editing}
+                  onChange={(val) => {
+                    const newData = { ...(data as ReportData) }
+                    newData.sections[sectionIndex].content[contentIndex] =
+                      val as ContentItem
+                    setData(newData)
+                  }}
                 />
               )
             })}

--- a/src/components/SettingsFloat.tsx
+++ b/src/components/SettingsFloat.tsx
@@ -1,24 +1,13 @@
 'use client'
-import { useRouter, usePathname } from 'next/navigation'
-import { useEffect, useState } from 'react'
 import { resetReportData } from '@/utils/db'
-import { RefreshCcw, Pencil, Eye, Printer } from 'lucide-react'
+import { RefreshCcw, Pencil, Eye, Printer, Save } from 'lucide-react'
+import { useReport } from '@/contexts/ReportContext'
 
 const SettingsFloat = () => {
-  const router = useRouter()
-  const pathname = usePathname()
-  const [editing, setEditing] = useState(false)
-
-  useEffect(() => {
-    setEditing(pathname.startsWith('/edit'))
-  }, [pathname])
+  const { editing, toggleEditing, save } = useReport()
 
   const toggle = () => {
-    if (editing) {
-      router.push('/')
-    } else {
-      router.push('/edit')
-    }
+    toggleEditing()
   }
 
   const reset = async () => {
@@ -39,6 +28,9 @@ const SettingsFloat = () => {
     <div className="fixed bottom-4 right-4 flex flex-col space-y-2 p-2 bg-white/70 backdrop-blur-md rounded-xl shadow z-50 print:hidden">
       <button onClick={toggle} className={btn} title={editing ? 'View mode' : 'Edit mode'}>
         {editing ? <Eye size={20} /> : <Pencil size={20} />}
+      </button>
+      <button onClick={() => save()} className={btn} title="Save changes">
+        <Save size={20} />
       </button>
       <button onClick={reset} className={btn} title="Reset data">
         <RefreshCcw size={20} />

--- a/src/components/StrategicVisionSection.tsx
+++ b/src/components/StrategicVisionSection.tsx
@@ -17,7 +17,7 @@ const StrategicVisionSection = ({ number }: Props) => {
           ? {
               contentEditable: true,
               suppressContentEditableWarning: true,
-              onInput: (e: React.FormEvent<HTMLElement>) => {
+              onBlur: (e: React.FocusEvent<HTMLElement>) => {
                 const newData = { ...(data as typeof data) }
                 newData.strategicVisionTitle = e.currentTarget.textContent || ''
                 setData(newData)
@@ -34,7 +34,7 @@ const StrategicVisionSection = ({ number }: Props) => {
           ? {
               contentEditable: true,
               suppressContentEditableWarning: true,
-              onInput: (e: React.FormEvent<HTMLElement>) => {
+              onBlur: (e: React.FocusEvent<HTMLElement>) => {
                 const newData = { ...(data as typeof data) }
                 newData.strategicVision.intro = e.currentTarget.textContent || ''
                 setData(newData)
@@ -64,7 +64,7 @@ const StrategicVisionSection = ({ number }: Props) => {
                       ? {
                           contentEditable: true,
                           suppressContentEditableWarning: true,
-                          onInput: (e: React.FormEvent<HTMLElement>) => {
+                          onBlur: (e: React.FocusEvent<HTMLElement>) => {
                             const newData = { ...(data as typeof data) }
                             newData.strategicVision.educationGoals[index].title =
                               e.currentTarget.textContent || ''
@@ -81,7 +81,7 @@ const StrategicVisionSection = ({ number }: Props) => {
                       ? {
                           contentEditable: true,
                           suppressContentEditableWarning: true,
-                          onInput: (e: React.FormEvent<HTMLElement>) => {
+                          onBlur: (e: React.FocusEvent<HTMLElement>) => {
                             const newData = { ...(data as typeof data) }
                             newData.strategicVision.educationGoals[index].description =
                               e.currentTarget.textContent || ''
@@ -116,7 +116,7 @@ const StrategicVisionSection = ({ number }: Props) => {
                       ? {
                           contentEditable: true,
                           suppressContentEditableWarning: true,
-                          onInput: (e: React.FormEvent<HTMLElement>) => {
+                          onBlur: (e: React.FocusEvent<HTMLElement>) => {
                             const newData = { ...(data as typeof data) }
                             newData.strategicVision.businessGoals[index].title =
                               e.currentTarget.textContent || ''
@@ -133,7 +133,7 @@ const StrategicVisionSection = ({ number }: Props) => {
                       ? {
                           contentEditable: true,
                           suppressContentEditableWarning: true,
-                          onInput: (e: React.FormEvent<HTMLElement>) => {
+                          onBlur: (e: React.FocusEvent<HTMLElement>) => {
                             const newData = { ...(data as typeof data) }
                             newData.strategicVision.businessGoals[index].description =
                               e.currentTarget.textContent || ''

--- a/src/components/StrategicVisionSection.tsx
+++ b/src/components/StrategicVisionSection.tsx
@@ -47,9 +47,23 @@ const StrategicVisionSection = ({ number }: Props) => {
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         <div className="bg-gradient-to-br from-blue-50 to-emerald-50 p-8 rounded-2xl border-l-4 border-blue-500">
-          <h3 className="text-xl font-bold text-blue-800 mb-4 flex items-center">
+          <h3
+            className="text-xl font-bold text-blue-800 mb-4 flex items-center"
+            {...(editing
+              ? {
+                  contentEditable: true,
+                  suppressContentEditableWarning: true,
+                  onBlur: (e: React.FocusEvent<HTMLElement>) => {
+                    const newData = { ...(data as typeof data) }
+                    newData.strategicVision.educationHeading =
+                      e.currentTarget.textContent || ''
+                    setData(newData)
+                  },
+                }
+              : {})}
+          >
             <GraduationCap className="mr-2" size={24} />
-            Education-Driven Goals
+            {data.strategicVision.educationHeading}
           </h3>
           <ul className="space-y-4">
             {data.strategicVision.educationGoals.map((goal, index) => (
@@ -99,9 +113,23 @@ const StrategicVisionSection = ({ number }: Props) => {
         </div>
 
         <div className="bg-gradient-to-br from-amber-50 to-emerald-50 p-8 rounded-2xl border-l-4 border-amber-500">
-          <h3 className="text-xl font-bold text-amber-800 mb-4 flex items-center">
+          <h3
+            className="text-xl font-bold text-amber-800 mb-4 flex items-center"
+            {...(editing
+              ? {
+                  contentEditable: true,
+                  suppressContentEditableWarning: true,
+                  onBlur: (e: React.FocusEvent<HTMLElement>) => {
+                    const newData = { ...(data as typeof data) }
+                    newData.strategicVision.businessHeading =
+                      e.currentTarget.textContent || ''
+                    setData(newData)
+                  },
+                }
+              : {})}
+          >
             <Handshake className="mr-2" size={24} />
-            Business-Driven Goals
+            {data.strategicVision.businessHeading}
           </h3>
           <ul className="space-y-4">
             {data.strategicVision.businessGoals.map((goal, index) => (

--- a/src/components/StrategicVisionSection.tsx
+++ b/src/components/StrategicVisionSection.tsx
@@ -1,21 +1,49 @@
 'use client'
-import useReportData from '@/hooks/useReportData'
+import { useReport } from '@/contexts/ReportContext'
 import { GraduationCap, Handshake } from 'lucide-react'
 import HeadingNumber from './HeadingNumber'
 
 interface Props { number: number }
 
 const StrategicVisionSection = ({ number }: Props) => {
-  const reportData = useReportData();
-  if (!reportData) return null;
+  const { data, setData, editing } = useReport();
+  if (!data) return null;
 
   return (
     <div id="vision" className="mb-20 scroll-mt-20 print:break-before">
-      <h2 className="text-3xl font-bold text-slate-800 mb-6 flex items-baseline">
+      <h2
+        className="text-3xl font-bold text-slate-800 mb-6 flex items-baseline"
+        {...(editing
+          ? {
+              contentEditable: true,
+              suppressContentEditableWarning: true,
+              onInput: (e: React.FormEvent<HTMLElement>) => {
+                const newData = { ...(data as typeof data) }
+                newData.strategicVisionTitle = e.currentTarget.textContent || ''
+                setData(newData)
+              },
+            }
+          : {})}
+      >
         <HeadingNumber number={number} />
-        Our Strategic Vision: A Blueprint for a Brighter Future
+        {data.strategicVisionTitle}
       </h2>
-      <p className="text-lg mb-8">{reportData.strategicVision.intro}</p>
+      <p
+        className="text-lg mb-8"
+        {...(editing
+          ? {
+              contentEditable: true,
+              suppressContentEditableWarning: true,
+              onInput: (e: React.FormEvent<HTMLElement>) => {
+                const newData = { ...(data as typeof data) }
+                newData.strategicVision.intro = e.currentTarget.textContent || ''
+                setData(newData)
+              },
+            }
+          : {})}
+      >
+        {data.strategicVision.intro}
+      </p>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         <div className="bg-gradient-to-br from-blue-50 to-emerald-50 p-8 rounded-2xl border-l-4 border-blue-500">
@@ -24,14 +52,46 @@ const StrategicVisionSection = ({ number }: Props) => {
             Education-Driven Goals
           </h3>
           <ul className="space-y-4">
-            {reportData.strategicVision.educationGoals.map((goal, index) => (
+            {data.strategicVision.educationGoals.map((goal, index) => (
               <li key={index} className="flex items-start">
                 <div className="bg-blue-100 p-2 rounded-full mr-3 mt-1">
                   <span className="text-blue-600 font-bold">{index + 1}.</span>
                 </div>
                 <div>
-                  <h4 className="font-bold text-slate-800">{goal.title}</h4>
-                  <p className="text-slate-700">{goal.description}</p>
+                  <h4
+                    className="font-bold text-slate-800"
+                    {...(editing
+                      ? {
+                          contentEditable: true,
+                          suppressContentEditableWarning: true,
+                          onInput: (e: React.FormEvent<HTMLElement>) => {
+                            const newData = { ...(data as typeof data) }
+                            newData.strategicVision.educationGoals[index].title =
+                              e.currentTarget.textContent || ''
+                            setData(newData)
+                          },
+                        }
+                      : {})}
+                  >
+                    {goal.title}
+                  </h4>
+                  <p
+                    className="text-slate-700"
+                    {...(editing
+                      ? {
+                          contentEditable: true,
+                          suppressContentEditableWarning: true,
+                          onInput: (e: React.FormEvent<HTMLElement>) => {
+                            const newData = { ...(data as typeof data) }
+                            newData.strategicVision.educationGoals[index].description =
+                              e.currentTarget.textContent || ''
+                            setData(newData)
+                          },
+                        }
+                      : {})}
+                  >
+                    {goal.description}
+                  </p>
                 </div>
               </li>
             ))}
@@ -44,14 +104,46 @@ const StrategicVisionSection = ({ number }: Props) => {
             Business-Driven Goals
           </h3>
           <ul className="space-y-4">
-            {reportData.strategicVision.businessGoals.map((goal, index) => (
+            {data.strategicVision.businessGoals.map((goal, index) => (
               <li key={index} className="flex items-start">
                 <div className="bg-amber-100 p-2 rounded-full mr-3 mt-1">
                   <span className="text-amber-600 font-bold">{index + 4}.</span>
                 </div>
                 <div>
-                  <h4 className="font-bold text-slate-800">{goal.title}</h4>
-                  <p className="text-slate-700">{goal.description}</p>
+                  <h4
+                    className="font-bold text-slate-800"
+                    {...(editing
+                      ? {
+                          contentEditable: true,
+                          suppressContentEditableWarning: true,
+                          onInput: (e: React.FormEvent<HTMLElement>) => {
+                            const newData = { ...(data as typeof data) }
+                            newData.strategicVision.businessGoals[index].title =
+                              e.currentTarget.textContent || ''
+                            setData(newData)
+                          },
+                        }
+                      : {})}
+                  >
+                    {goal.title}
+                  </h4>
+                  <p
+                    className="text-slate-700"
+                    {...(editing
+                      ? {
+                          contentEditable: true,
+                          suppressContentEditableWarning: true,
+                          onInput: (e: React.FormEvent<HTMLElement>) => {
+                            const newData = { ...(data as typeof data) }
+                            newData.strategicVision.businessGoals[index].description =
+                              e.currentTarget.textContent || ''
+                            setData(newData)
+                          },
+                        }
+                      : {})}
+                  >
+                    {goal.description}
+                  </p>
                 </div>
               </li>
             ))}

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { Dispatch, SetStateAction } from 'react'
 import { BookOpen } from 'lucide-react'
-import useReportData from '@/hooks/useReportData'
+import { useReport } from '@/contexts/ReportContext'
 
 interface TocItem {
   id: string
@@ -15,8 +15,8 @@ interface Props {
 }
 
 const TableOfContents = ({ items, active, setActive }: Props) => {
-  const reportData = useReportData()
-  if (!reportData) return null
+  const { data, setData, editing } = useReport()
+  if (!data) return null
   const circleColor = (index: number) => {
     const startHue = 160
     const endHue = 220
@@ -27,12 +27,55 @@ const TableOfContents = ({ items, active, setActive }: Props) => {
   return (
     <div className="mb-20 p-8 mx-8 print:break-before print:break-after">
       <div className="mb-12 text-center p-6 bg-gradient-to-r from-emerald-50 to-amber-50 rounded-xl">
-        <p className="text-xl italic text-emerald-700 mb-6">“{reportData.guidingPrinciple}”</p>
-        <p className="text-lg text-slate-700">{reportData.mission}</p>
+        <p
+          className="text-xl italic text-emerald-700 mb-6"
+          {...(editing
+            ? {
+                contentEditable: true,
+                suppressContentEditableWarning: true,
+                onBlur: (e: React.FocusEvent<HTMLElement>) => {
+                  const newData = { ...(data as typeof data) }
+                  newData.guidingPrinciple = e.currentTarget.textContent || ''
+                  setData(newData)
+                },
+              }
+            : {})}
+        >
+          “{data.guidingPrinciple}”
+        </p>
+        <p
+          className="text-lg text-slate-700"
+          {...(editing
+            ? {
+                contentEditable: true,
+                suppressContentEditableWarning: true,
+                onBlur: (e: React.FocusEvent<HTMLElement>) => {
+                  const newData = { ...(data as typeof data) }
+                  newData.mission = e.currentTarget.textContent || ''
+                  setData(newData)
+                },
+              }
+            : {})}
+        >
+          {data.mission}
+        </p>
       </div>
-      <h2 className="text-3xl font-bold text-slate-800 mb-6 flex items-center">
+      <h2
+        className="text-3xl font-bold text-slate-800 mb-6 flex items-center"
+        {...(editing
+          ? {
+              contentEditable: true,
+              suppressContentEditableWarning: true,
+              onBlur: (e: React.FocusEvent<HTMLElement>) => {
+                const newData = { ...(data as typeof data) }
+                newData.tocTitle = e.currentTarget.textContent || ''
+                setData(newData)
+              },
+            }
+          : {})}
+      >
         <BookOpen className="mr-3 text-emerald-600" size={32} />
-        Table of Contents
+        {data.tocTitle}
       </h2>
       <ul className="space-y-3">
         {items.map((item, index) => (

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -1,17 +1,30 @@
 'use client'
-import useReportData from '@/hooks/useReportData'
+import { useReport } from '@/contexts/ReportContext'
 import HeadingNumber from './HeadingNumber'
 
 interface Props { number: number }
 
 const TimelineSection = ({ number }: Props) => {
-  const data = useReportData()
+  const { data, setData, editing } = useReport()
   if (!data) return null
   return (
     <div id="timeline" className="mb-20 scroll-mt-20 print:break-before">
-      <h2 className="text-3xl font-bold text-slate-800 mb-10 flex items-baseline">
+      <h2
+        className="text-3xl font-bold text-slate-800 mb-10 flex items-baseline"
+        {...(editing
+          ? {
+              contentEditable: true,
+              suppressContentEditableWarning: true,
+              onInput: (e: React.FormEvent<HTMLElement>) => {
+                const newData = { ...(data as typeof data) }
+                newData.timelineTitle = e.currentTarget.textContent || ''
+                setData(newData)
+              },
+            }
+          : {})}
+      >
         <HeadingNumber number={number} />
-        Progress Timeline
+        {data.timelineTitle}
       </h2>
       <div className="relative ml-6">
         <div className="absolute left-5 top-5 bottom-5 w-0.5 bg-emerald-500 z-0"></div>
@@ -26,8 +39,40 @@ const TimelineSection = ({ number }: Props) => {
               )}
             </div>
             <div>
-              <h3 className="font-bold text-emerald-700 mb-1">{m.title}</h3>
-              <p className="text-slate-700">{m.description}</p>
+              <h3
+                className="font-bold text-emerald-700 mb-1"
+                {...(editing
+                  ? {
+                      contentEditable: true,
+                      suppressContentEditableWarning: true,
+                      onInput: (e: React.FormEvent<HTMLElement>) => {
+                        const newData = { ...(data as typeof data) }
+                        newData.milestones[idx].title =
+                          e.currentTarget.textContent || ''
+                        setData(newData)
+                      },
+                    }
+                  : {})}
+              >
+                {m.title}
+              </h3>
+              <p
+                className="text-slate-700"
+                {...(editing
+                  ? {
+                      contentEditable: true,
+                      suppressContentEditableWarning: true,
+                      onInput: (e: React.FormEvent<HTMLElement>) => {
+                        const newData = { ...(data as typeof data) }
+                        newData.milestones[idx].description =
+                          e.currentTarget.textContent || ''
+                        setData(newData)
+                      },
+                    }
+                  : {})}
+              >
+                {m.description}
+              </p>
             </div>
           </div>
         ))}

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -15,7 +15,7 @@ const TimelineSection = ({ number }: Props) => {
           ? {
               contentEditable: true,
               suppressContentEditableWarning: true,
-              onInput: (e: React.FormEvent<HTMLElement>) => {
+              onBlur: (e: React.FocusEvent<HTMLElement>) => {
                 const newData = { ...(data as typeof data) }
                 newData.timelineTitle = e.currentTarget.textContent || ''
                 setData(newData)
@@ -45,7 +45,7 @@ const TimelineSection = ({ number }: Props) => {
                   ? {
                       contentEditable: true,
                       suppressContentEditableWarning: true,
-                      onInput: (e: React.FormEvent<HTMLElement>) => {
+                      onBlur: (e: React.FocusEvent<HTMLElement>) => {
                         const newData = { ...(data as typeof data) }
                         newData.milestones[idx].title =
                           e.currentTarget.textContent || ''
@@ -62,7 +62,7 @@ const TimelineSection = ({ number }: Props) => {
                   ? {
                       contentEditable: true,
                       suppressContentEditableWarning: true,
-                      onInput: (e: React.FormEvent<HTMLElement>) => {
+                      onBlur: (e: React.FocusEvent<HTMLElement>) => {
                         const newData = { ...(data as typeof data) }
                         newData.milestones[idx].description =
                           e.currentTarget.textContent || ''

--- a/src/contexts/ReportContext.tsx
+++ b/src/contexts/ReportContext.tsx
@@ -1,0 +1,67 @@
+'use client'
+import React, { createContext, useContext, useEffect, useState } from 'react'
+import { ReportData } from '@/types/report'
+import { db, REPORT_ID, resetReportData } from '@/utils/db'
+
+type ReportContextType = {
+  data: ReportData | null
+  setData: React.Dispatch<React.SetStateAction<ReportData | null>>
+  save: () => Promise<void>
+  reset: () => Promise<void>
+  editing: boolean
+  toggleEditing: () => void
+}
+
+const ReportContext = createContext<ReportContextType | undefined>(undefined)
+
+export const ReportProvider = ({ children }: { children: React.ReactNode }) => {
+  const [data, setData] = useState<ReportData | null>(null)
+  const [editing, setEditing] = useState(false)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const existing = await db.table('report').get(REPORT_ID)
+        if (existing) {
+          setData(existing as ReportData)
+        } else {
+          const fresh = await resetReportData()
+          setData(fresh)
+        }
+      } catch (err) {
+        console.error('Failed to load report from IndexedDB', err)
+        const fresh = await resetReportData()
+        setData(fresh)
+      }
+    }
+    load()
+  }, [])
+
+  const save = async () => {
+    if (!data) return
+    await db.table('report').put({ ...(data as ReportData), id: REPORT_ID })
+  }
+
+  const reset = async () => {
+    const fresh = await resetReportData()
+    setData(fresh)
+  }
+
+  const toggleEditing = () => setEditing((e) => !e)
+
+  return (
+    <ReportContext.Provider
+      value={{ data, setData, save, reset, editing, toggleEditing }}
+    >
+      {children}
+    </ReportContext.Provider>
+  )
+}
+
+export const useReport = () => {
+  const ctx = useContext(ReportContext)
+  if (!ctx) throw new Error('useReport must be used within ReportProvider')
+  return ctx
+}
+
+export default ReportContext

--- a/src/data/report.ts
+++ b/src/data/report.ts
@@ -7,6 +7,7 @@ export const reportData: ReportData = {
   period: "January – June 2025",
   guidingPrinciple: "Providing universal access to quality education",
   mission: "We envision empowered rural communities where all children have access to quality education, regardless of their gender or socio-economic backgrounds.",
+  tocTitle: 'Table of Contents',
   message: {
     title: "A Message of Gratitude and Progress",
     content: [
@@ -64,6 +65,7 @@ export const reportData: ReportData = {
   timelineTitle: 'Progress Timeline',
   strategicVision: {
     intro: "TTI's common goal is to provide universal access to quality education and develop an educational system that is sustainable and not solely reliant on external funding. To accomplish this, our work is guided by six core goals:",
+    educationHeading: 'Education-Driven Goals',
     educationGoals: [
       {
         title: "Improving Education Quality",
@@ -78,6 +80,7 @@ export const reportData: ReportData = {
         description: "Promoting modern educational tools and programs to enable students to attain higher education degrees and valuable certifications."
       }
     ],
+    businessHeading: 'Business-Driven Goals',
     businessGoals: [
       {
         title: "Establishing a Self-Sustainable Organization",
@@ -181,6 +184,11 @@ export const reportData: ReportData = {
     "Continue construction of the Chivakanenyama Secondary School classroom block.",
     "Conduct a full financial review of all H1 2025 projects."
   ],
+  futureVisionImage: {
+    src: 'https://images.unsplash.com/photo-1523580494863-6f3031224c94',
+    alt: 'Future vision',
+    caption: 'Vision for the new Library and Computer Lab at Musukwi Secondary',
+  },
   locationsTitle: 'Where We Work',
   locations: [
     { name: 'Chivakanenyama Secondary School', lat: -16.712, lng: 29.164 },

--- a/src/data/report.ts
+++ b/src/data/report.ts
@@ -21,6 +21,7 @@ export const reportData: ReportData = {
       }
     ]
   },
+  impactTitle: "Our Impact at a Glance",
   milestones: [
     {
       title: "Expanded Our Scholarship Program",
@@ -51,6 +52,7 @@ export const reportData: ReportData = {
       description: "including a fuel-saver vehicle for local travel, two significant stationery donations, and laboratory equipment from OSU."
     }
   ],
+  highlightsTitle: 'Key Highlights',
   highlights: [
     { label: 'New Female Students', value: 10, icon: 'UserPlus' },
     { label: 'Boreholes Drilled', value: 3, icon: 'Droplet' },
@@ -59,6 +61,7 @@ export const reportData: ReportData = {
     { label: 'Partner Students on Tour', value: 20, icon: 'Globe' },
     { label: 'Classrooms Built', value: 1, icon: 'Building2' }
   ],
+  timelineTitle: 'Progress Timeline',
   strategicVision: {
     intro: "TTI's common goal is to provide universal access to quality education and develop an educational system that is sustainable and not solely reliant on external funding. To accomplish this, our work is guided by six core goals:",
     educationGoals: [
@@ -86,6 +89,7 @@ export const reportData: ReportData = {
       }
     ]
   },
+  strategicVisionTitle: 'Our Strategic Vision: A Blueprint for a Brighter Future',
   sections: [
     {
       title: "Empowering Minds, One Student at a Time",
@@ -168,6 +172,7 @@ export const reportData: ReportData = {
       ]
     }
   ],
+  futureGoalsTitle: 'Looking Ahead: Our Goals for H2 2025',
   futureGoals: [
     "Conduct our 2nd Half Strategic Review Meeting to assess progress and refine our plans.",
     "Complete the Borehole and Fence Installation for the Chiroti Primary garden project.",
@@ -176,11 +181,13 @@ export const reportData: ReportData = {
     "Continue construction of the Chivakanenyama Secondary School classroom block.",
     "Conduct a full financial review of all H1 2025 projects."
   ],
+  locationsTitle: 'Where We Work',
   locations: [
     { name: 'Chivakanenyama Secondary School', lat: -16.712, lng: 29.164 },
     { name: 'Zvimhonja Primary School', lat: -16.745, lng: 29.123 },
     { name: 'Denderedzi Secondary School', lat: -16.737, lng: 29.138 }
   ],
+  closingTitle: 'A Heartfelt Thank You',
   closing: "None of this would be possible without you—our dedicated partners, donors, and the resilient communities we serve. Your belief in our mission fuels our work and turns dreams into reality for thousands of children. Together, we are not just providing education; we are building a legacy of empowerment, sustainability, and hope. Thank you for being a part of this incredible journey.",
   closingImage: {
     src: "https://images.unsplash.com/photo-1522071820081-009f0129c71c",

--- a/src/hooks/useEditableReportData.ts
+++ b/src/hooks/useEditableReportData.ts
@@ -1,41 +1,10 @@
+
 'use client'
-import { useEffect, useState } from 'react'
-import { ReportData } from '@/types/report'
-import { db, REPORT_ID, resetReportData } from '@/utils/db'
+import { useReport } from '@/contexts/ReportContext'
 
-// Hook that loads report data from Dexie and allows saving updates
+// Hook exposing report editing utilities from context
 const useEditableReportData = () => {
-  const [data, setData] = useState<ReportData | null>(null)
-
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const existing = await db.table('report').get(REPORT_ID)
-        if (existing) {
-          setData(existing as ReportData)
-        } else {
-          const fresh = await resetReportData()
-          setData(fresh)
-        }
-      } catch (err) {
-        console.error('Failed to load report from IndexedDB', err)
-        const fresh = await resetReportData()
-        setData(fresh)
-      }
-    }
-    load()
-  }, [])
-
-  const save = async (newData: ReportData) => {
-    await db.table('report').put({ ...(newData as ReportData), id: REPORT_ID })
-    setData(newData)
-  }
-
-  const reset = async () => {
-    const fresh = await resetReportData()
-    setData(fresh)
-  }
-
+  const { data, setData, save, reset } = useReport()
   return { data, setData, save, reset }
 }
 

--- a/src/hooks/useReportData.ts
+++ b/src/hooks/useReportData.ts
@@ -1,30 +1,10 @@
+
 'use client';
-import { useEffect, useState } from 'react';
 import { ReportData } from '@/types/report';
-import { db, REPORT_ID, resetReportData } from '@/utils/db';
+import { useReport } from '@/contexts/ReportContext';
 
 const useReportData = (): ReportData | null => {
-  const [data, setData] = useState<ReportData | null>(null);
-
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const existing = await db.table('report').get(REPORT_ID);
-        if (existing) {
-          setData(existing as ReportData);
-        } else {
-          const fresh = await resetReportData();
-          setData(fresh);
-        }
-      } catch (err) {
-        console.error('Failed to load report from IndexedDB', err);
-        const fresh = await resetReportData();
-        setData(fresh);
-      }
-    };
-    load();
-  }, []);
-
+  const { data } = useReport();
   return data;
 };
 

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -51,16 +51,23 @@ export interface ReportData {
     content: (string | ContentItem)[]; // Allow mixed content types
   };
   milestones: Milestone[];
+  impactTitle: string;
   strategicVision: {
     intro: string;
     educationGoals: CoreGoal[];
     businessGoals: CoreGoal[];
   };
+  strategicVisionTitle: string;
   highlights?: HighlightStat[];
+  highlightsTitle: string;
   sections: Section[];
+  timelineTitle: string;
   futureGoals: string[];
+  futureGoalsTitle: string;
   locations: MapLocation[]
+  locationsTitle: string;
   closing: string;
+  closingTitle: string;
   closingImage?: { // Optional closing image
     src: string;
     alt: string;

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -46,6 +46,7 @@ export interface ReportData {
   period: string;
   guidingPrinciple: string;
   mission: string;
+  tocTitle: string;
   message: {
     title: string;
     content: (string | ContentItem)[]; // Allow mixed content types
@@ -54,7 +55,9 @@ export interface ReportData {
   impactTitle: string;
   strategicVision: {
     intro: string;
+    educationHeading: string;
     educationGoals: CoreGoal[];
+    businessHeading: string;
     businessGoals: CoreGoal[];
   };
   strategicVisionTitle: string;
@@ -64,6 +67,11 @@ export interface ReportData {
   timelineTitle: string;
   futureGoals: string[];
   futureGoalsTitle: string;
+  futureVisionImage?: {
+    src: string;
+    alt: string;
+    caption: string;
+  };
   locations: MapLocation[]
   locationsTitle: string;
   closing: string;


### PR DESCRIPTION
## Summary
- add global ReportContext for editing and saving
- update layout to use ReportProvider and always show settings float
- make settings float toggle edit mode and save changes
- switch edit page to use ReportViewer and allow in-place editing
- modify Message and Sections to support contentEditable when editing
- adapt hooks and editor to new context

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f9aefde188321ae71a903d694008e