### PR TITLE
Add editable image component

### DIFF
--- a/src/components/ClosingSection.tsx
+++ b/src/components/ClosingSection.tsx
@@ -1,6 +1,7 @@
 'use client'
 import useReportData from '@/hooks/useReportData'
 import HeadingNumber from './HeadingNumber'
+import EditableImage from './EditableImage'
 
 interface Props { number: number }
 
@@ -16,10 +17,14 @@ const ClosingSection = ({ number }: Props) => {
       </h3>
       {reportData.closingImage && (
         <div className="mt-12 mb-8 max-w-3xl mx-auto print:break-inside-avoid">
-          <div className="relative w-full h-96 rounded-2xl overflow-hidden shadow-xl">
-            <img src={reportData.closingImage.src} alt={reportData.closingImage.alt} className="w-full h-full object-cover" />
-          </div>
-          <p className="text-center text-sm text-gray-600 italic mt-2">{reportData.closingImage.caption}</p>
+          <EditableImage
+            src={reportData.closingImage.src}
+            alt={reportData.closingImage.alt}
+            caption={reportData.closingImage.caption}
+            width={reportData.closingImage.width}
+            height={reportData.closingImage.height}
+            containerClassName="w-full rounded-2xl overflow-hidden shadow-xl"
+          />
         </div>
       )}
       <p className="text-xl text-slate-600 max-w-3xl mx-auto">{reportData.closing}</p>

--- a/src/components/ContentRenderer.tsx
+++ b/src/components/ContentRenderer.tsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import { ContentItem } from '@/types/report'
 import HeadingNumber from './HeadingNumber'
+import EditableImage from './EditableImage'
 
 interface Props {
   content: ContentItem | string
@@ -87,39 +88,17 @@ const ContentRenderer = ({ content, index, subheadingNumber, editable, onChange 
       )
     case 'image':
       return (
-        <figure
+        <EditableImage
           key={index}
-          className={`my-8 print:break-inside-avoid ${content.layout === 'split' ? 'flex flex-col gap-8 items-center' : ''}`}
-        >
-          <div
-            className={`relative overflow-hidden rounded-xl shadow-lg ${content.layout === 'split' ? 'md:w-1/2' : ''}`}
-            style={{ height: content.layout === 'split' ? '300px' : '400px' }}
-          >
-            <img src={content.src} alt={content.alt} className="w-full h-full object-cover" />
-          </div>
-          {editable ? (
-            <>
-              <figcaption
-                className={`mt-2 text-sm text-gray-600 italic ${content.layout === 'split' ? 'md:w-1/2' : ''}`}
-                {...editableProps((val) => onChange?.({ ...content, caption: val }))}
-              >
-                {content.caption}
-              </figcaption>
-              <p className="text-sm text-gray-500">
-                Src:{' '}
-                <span {...editableProps((val) => onChange?.({ ...content, src: val }))}>{content.src}</span>
-              </p>
-              <p className="text-sm text-gray-500">
-                Alt:{' '}
-                <span {...editableProps((val) => onChange?.({ ...content, alt: val }))}>{content.alt}</span>
-              </p>
-            </>
-          ) : (
-            content.caption && (
-              <figcaption className={`mt-2 text-sm text-gray-600 italic ${content.layout === 'split' ? 'md:w-1/2' : ''}`}>{content.caption}</figcaption>
-            )
-          )}
-        </figure>
+          src={content.src}
+          alt={content.alt}
+          caption={content.caption}
+          width={content.width}
+          height={content.height}
+          layout={content.layout}
+          editable={editable}
+          onChange={(val) => onChange?.({ ...content, ...val })}
+        />
       )
     default:
       return null

--- a/src/components/CoverPage.tsx
+++ b/src/components/CoverPage.tsx
@@ -1,5 +1,6 @@
 'use client'
 import useReportData from '@/hooks/useReportData';
+import EditableImage from './EditableImage';
 
 const CoverPage = () => {
   const reportData = useReportData();
@@ -23,13 +24,14 @@ const CoverPage = () => {
         {reportData.organization}<br />
         {reportData.period}
       </p>
-      <div className="relative w-64 h-64 rounded-full overflow-hidden border-8 border-emerald-100 shadow-xl mx-auto">
-        <img
-          src="https://images.unsplash.com/photo-1523050854058-8df90110c9f1"
-          alt="African students learning"
-          className="w-full h-full object-cover opacity-90"
-        />
-      </div>
+      <EditableImage
+        src="https://images.unsplash.com/photo-1523050854058-8df90110c9f1"
+        alt="African students learning"
+        width={256}
+        height={256}
+        imgClassName="opacity-90 rounded-full"
+        containerClassName="mx-auto overflow-hidden rounded-full border-8 border-emerald-100 shadow-xl"
+      />
     </div>
   </div>
   );

--- a/src/components/EditableImage.tsx
+++ b/src/components/EditableImage.tsx
@@ -1,0 +1,107 @@
+'use client'
+import React, { useState } from 'react'
+
+interface Props {
+  src: string
+  alt: string
+  caption?: string
+  width?: number
+  height?: number
+  layout?: 'full' | 'split'
+  editable?: boolean
+  onChange?: (val: { src: string; width?: number; height?: number }) => void
+  containerClassName?: string
+  imgClassName?: string
+}
+
+const EditableImage = ({
+  src,
+  alt,
+  caption,
+  width,
+  height,
+  layout,
+  editable,
+  onChange,
+  containerClassName,
+  imgClassName
+}: Props) => {
+  const [localSrc, setLocalSrc] = useState(src)
+  const w = width ?? (layout === 'split' ? 400 : 600)
+  const h = height ?? (layout === 'split' ? 300 : 400)
+
+  const handleUpload = (file: File) => {
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      const result = e.target?.result as string
+      if (result) {
+        setLocalSrc(result)
+        onChange?.({ src: result, width: w, height: h })
+      }
+    }
+    reader.readAsDataURL(file)
+  }
+
+  const updateDims = (nw: number, nh: number) => {
+    onChange?.({ src: localSrc, width: nw, height: nh })
+  }
+
+  return (
+    <figure
+      className={`my-8 print:break-inside-avoid ${
+        layout === 'split' ? 'flex flex-col gap-8 items-center' : ''
+      } ${containerClassName ?? ''}`}
+    >
+      <div
+        className={`relative overflow-hidden rounded-xl shadow-lg ${
+          layout === 'split' ? 'md:w-1/2' : ''
+        }`}
+        style={{ width: w, height: h }}
+      >
+        <img
+          src={localSrc}
+          alt={alt}
+          className={`w-full h-full object-cover ${imgClassName ?? ''}`}
+        />
+      </div>
+      {caption && (
+        <figcaption
+          className={`mt-2 text-sm text-gray-600 italic ${
+            layout === 'split' ? 'md:w-1/2' : ''
+          }`}
+        >
+          {caption}
+        </figcaption>
+      )}
+      {editable && (
+        <div className="mt-2 space-x-2 text-sm flex items-center">
+          <input
+            type="file"
+            accept="image/*"
+            onChange={(e) => e.target.files && handleUpload(e.target.files[0])}
+          />
+          <label>
+            W:
+            <input
+              type="number"
+              value={w}
+              onChange={(e) => updateDims(Number(e.target.value), h)}
+              className="border px-1 w-20 ml-1"
+            />
+          </label>
+          <label>
+            H:
+            <input
+              type="number"
+              value={h}
+              onChange={(e) => updateDims(w, Number(e.target.value))}
+              className="border px-1 w-20 ml-1"
+            />
+          </label>
+        </div>
+      )}
+    </figure>
+  )
+}
+
+export default EditableImage

--- a/src/components/FutureGoalsSection.tsx
+++ b/src/components/FutureGoalsSection.tsx
@@ -1,6 +1,7 @@
 'use client'
 import useReportData from '@/hooks/useReportData'
 import HeadingNumber from './HeadingNumber'
+import EditableImage from './EditableImage'
 
 interface Props { number: number }
 
@@ -25,12 +26,14 @@ const FutureGoalsSection = ({ number }: Props) => {
       ))}
     </div>
     <div className="mt-12 print:break-inside-avoid">
-      <div className="relative w-full h-80 rounded-2xl overflow-hidden shadow-xl">
-        <img src="https://images.unsplash.com/photo-1523580494863-6f3031224c94" alt="Future vision" className="w-full h-full object-cover" />
-      </div>
-      <p className="text-center text-sm text-gray-600 italic mt-2">
-        Vision for the new Library and Computer Lab at Musukwi Secondary
-      </p>
+      <EditableImage
+        src="https://images.unsplash.com/photo-1523580494863-6f3031224c94"
+        alt="Future vision"
+        width={800}
+        height={320}
+        caption="Vision for the new Library and Computer Lab at Musukwi Secondary"
+        containerClassName="w-full rounded-2xl overflow-hidden shadow-xl"
+      />
     </div>
   </div>
   );

--- a/src/data/report.ts
+++ b/src/data/report.ts
@@ -12,10 +12,12 @@ export const reportData: ReportData = {
     content: [
       "The first half of 2025 has been a period of incredible growth and transformative impact for the Tererai Trent International (TTI) Foundation. With the unwavering support of our partners, donors, and community members, we have made significant strides in our core focus areas of educational support, sustainable agriculture, and community empowerment.",
       "This report celebrates the milestones we have achieved together. It tells the story of how three key initiatives—our scholarship program, an income-generating sewing project, and school-based irrigation systems—are not just changing lives but are building a foundation for a self-sustaining future. We are thrilled to share our progress, acknowledge the challenges we've faced, and look ahead with renewed purpose to the work that still needs to be done.",
-      { 
-        type: "image", 
-        src: "https://images.unsplash.com/photo-1517430816045-df4b7de11d1d", 
+      {
+        type: "image",
+        src: "https://images.unsplash.com/photo-1517430816045-df4b7de11d1d",
         alt: "Community gathering",
+        width: 600,
+        height: 400,
           caption: "Figure 1: Community members and TTI staff celebrating progress in education initiatives",
         layout: "full"
       }
@@ -94,20 +96,24 @@ export const reportData: ReportData = {
         { type: "paragraph", text: "Our scholarship program remains the cornerstone of our commitment to educational access. This half-year, we proudly supported 28 tertiary students and 3 Advanced Level high school students, covering their tuition, accommodation, and food. Strategic follow-ups ensured that our support was aligned with both their academic performance and individual needs." },
         { type: "paragraph", text: "We are thrilled to announce that we welcomed 10 more brilliant young women into the program. Empowering a girl is one of the most profound investments we can make. When girls are educated in safe, encouraging environments, they are more likely to stay in school, avoid early marriage, and make informed choices about their futures. They become leaders who uplift their families and communities, breaking the cycle of poverty for generations to come." },
         { type: "paragraph", text: "A landmark achievement this period was celebrating Tryness Nyauvanga and Christabel Dura, the first TTI-supported students to pursue a degree in Software Engineering. Their courage in entering a male-dominated field is a powerful testament to our efforts in promoting STEM education for girls. To support their journey, TTI provided each with a new laptop, removing a critical barrier to their success." },
-        { 
-          type: "image", 
-          src: "https://images.unsplash.com/photo-1571260899304-425eee4c7efc", 
+        {
+          type: "image",
+          src: "https://images.unsplash.com/photo-1571260899304-425eee4c7efc",
           alt: "Students receiving scholarships",
+          width: 400,
+          height: 300,
           caption: "Figure 2: Scholarship recipients at the January 2025 orientation",
           layout: "split"
         },
         { type: "subheading", text: "Scholarship Orientation: Building a Community of Leaders" },
         { type: "paragraph", text: "In January 2025, thanks to our generous donors, we held our first-ever orientation for 27 scholarship beneficiaries. This session was more than an introduction; it was a community-building experience. Students learned practical skills like time management and goal setting, connected with peers and mentors, and aligned their personal journeys with TTI's mission to uplift and empower." },
         { type: "quote", text: "Before the orientation, I was nervous and unsure about what to expect. But after hearing stories and guidance, I felt confident and ready to focus on my goals. I now understand that this scholarship is not just about school fees; it's about shaping my future.", author: "Christabel Dura" },
-        { 
-          type: "image", 
-          src: "https://images.unsplash.com/photo-1584697964358-3e14ca57658b", 
+        {
+          type: "image",
+          src: "https://images.unsplash.com/photo-1584697964358-3e14ca57658b",
           alt: "School supplies donation",
+          width: 600,
+          height: 400,
           caption: "Figure 3: Distribution of exercise books to students in need",
           layout: "full"
         },
@@ -121,30 +127,36 @@ export const reportData: ReportData = {
         { type: "paragraph", text: "Beyond direct scholarships, our strategy focuses on building systems that foster independence and create lasting change." },
         { type: "subheading", text: "Vocational Training: From Skills to Enterprise" },
         { type: "paragraph", text: "The Skills and Business Center, established in late 2024, is already bearing fruit. This reporting period, we successfully integrated 80% of the women trained in fashion and tailoring into a new school uniform production initiative." },
-        { 
-          type: "image", 
-          src: "https://images.unsplash.com/photo-1600267165477-6d4cc741b379", 
+        {
+          type: "image",
+          src: "https://images.unsplash.com/photo-1600267165477-6d4cc741b379",
           alt: "Women sewing uniforms",
+          width: 400,
+          height: 300,
           caption: "Figure 4: Women from the vocational training program producing school uniforms",
           layout: "split"
         },
         { type: "paragraph", text: "This community-led enterprise addresses multiple needs at once. By producing affordable, locally-made uniforms, we are easing the financial burden on families and improving school attendance. More importantly, we are providing graduates of our training program with immediate, meaningful employment. The income generated not only strengthens household resilience but is also channeled back into our scholarship fund, creating a virtuous, sustainable cycle." },
         { type: "subheading", text: "Science Labs: Opening a World of Possibility" },
         { type: "paragraph", text: "In the past, over 88% of students in the Matau cluster graduated with an Arts focus, largely due to a lack of science facilities. This year, we shattered that barrier by introducing and completing two modern science laboratories at Chivakanenyama and Zvimhonja Secondary Schools." },
-        { 
-          type: "image", 
+        {
+          type: "image",
           src: "https://images.unsplash.com/photo-1532094349884-543bc11b234d",
           alt: "Science laboratory",
+          width: 600,
+          height: 400,
           caption: "Figure 5: New science lab at Zvimhonja Secondary School",
           layout: "full"
         },
         { type: "paragraph", text: "A science lab levels the playing field, giving rural students the same opportunities as their urban peers. It ignites dreams of becoming doctors, engineers, and innovators. The impact was immediate: Chivakanenyama Secondary has been upgraded to a High School and is now offering Advanced Level science classes. A donation of a microscope and other lab equipment from visiting OSU students has already enabled the first practical science lessons, marking a new era of education in Matau." },
         { type: "subheading", text: "Solar-Powered Irrigation: Cultivating a Sustainable Future" },
         { type: "paragraph", text: "Access to water is fundamental to health, hygiene, and economic prosperity. We are proud to report the successful drilling of 3 boreholes at Chiroti Primary, Zvimhinja Primary, and Denderedzi Secondary." },
-        { 
-          type: "image", 
-          src: "https://images.unsplash.com/photo-1560785496-3c9d27877182", 
+        {
+          type: "image",
+          src: "https://images.unsplash.com/photo-1560785496-3c9d27877182",
           alt: "Solar-powered irrigation",
+          width: 400,
+          height: 300,
           caption: "Figure 6: Solar-powered garden at Denderedzi Primary School",
           layout: "split"
         },
@@ -155,10 +167,12 @@ export const reportData: ReportData = {
       title: "Strengthening Our Roots Through Partnership",
       content: [
         { type: "subheading", text: "Leadership Tours: Building Bridges and Trust" },
-        { 
-          type: "image", 
-          src: "https://images.unsplash.com/photo-1517245386807-bb43f82c33c4", 
+        {
+          type: "image",
+          src: "https://images.unsplash.com/photo-1517245386807-bb43f82c33c4",
           alt: "Leadership tour",
+          width: 400,
+          height: 300,
           caption: "Figure 7: OSU students visiting TTI projects in Zimbabwe",
           layout: "split"
         },
@@ -185,6 +199,8 @@ export const reportData: ReportData = {
   closingImage: {
     src: "https://images.unsplash.com/photo-1522071820081-009f0129c71c",
     alt: "TTI team and partners",
-    caption: "Figure 8: TTI team members with community partners and donors"
+    caption: "Figure 8: TTI team members with community partners and donors",
+    width: 600,
+    height: 400
   }
 };

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -10,12 +10,14 @@ export type ContentItem =
   | { type: 'list'; items: string[] }
   | { type: 'subheading'; text: string }
   | { type: 'bold'; text: string }
-  | { 
-      type: 'image'; 
-      src: string; 
-      alt: string; 
-      layout?: 'full' | 'split'; 
-      caption: string 
+  | {
+      type: 'image';
+      src: string;
+      alt: string;
+      width?: number;
+      height?: number;
+      layout?: 'full' | 'split';
+      caption: string
     };
 
 export interface Milestone {
@@ -65,5 +67,7 @@ export interface ReportData {
     src: string;
     alt: string;
     caption: string;
+    width?: number;
+    height?: number;
   };
 }


### PR DESCRIPTION
## Summary
- introduce `EditableImage` component to manage uploads and resizing
- extend report types and data with optional image dimensions
- update `ContentRenderer` and all sections to use the new component

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685f9b63976c832181a2a829228b245d