### PR TITLE
Add JSON tree editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "react": "^19.0.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
-        "react-leaflet": "^5.0.0"
+        "react-leaflet": "^5.0.0",
+        "react18-json-view": "^0.2.9"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2439,6 +2440,15 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "license": "MIT",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5217,6 +5227,18 @@
         "react-dom": "^19.0.0"
       }
     },
+    "node_modules/react18-json-view": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/react18-json-view/-/react18-json-view-0.2.9.tgz",
+      "integrity": "sha512-z3JQgCwZRKbmWh54U94loCU6vE0ZoDBK7C8ZpcMYQB8jYMi+mR/fcgMI9jKgATeF0I6+OAF025PD+UKkXIqueQ==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-to-clipboard": "^3.3.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -5926,6 +5948,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
-    "react-leaflet": "^5.0.0"
+    "react-leaflet": "^5.0.0",
+    "react18-json-view": "^0.2.9"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/update/page.tsx
+++ b/src/app/update/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+import DataTreeEditor from '@/components/DataTreeEditor'
+
+const UpdatePage = () => {
+  return <DataTreeEditor />
+}
+
+export default UpdatePage

--- a/src/components/DataTreeEditor.tsx
+++ b/src/components/DataTreeEditor.tsx
@@ -1,0 +1,33 @@
+'use client'
+import JsonView from 'react18-json-view'
+import 'react18-json-view/src/style.css'
+import { useReport } from '@/contexts/ReportContext'
+import { ReportData } from '@/types/report'
+
+const DataTreeEditor = () => {
+  const { data, setData, save } = useReport()
+
+  if (!data) return <p>Loading...</p>
+
+  const update = (src: unknown) => {
+    const cloned = JSON.parse(JSON.stringify(src)) as ReportData
+    setData(cloned)
+    save()
+  }
+
+  return (
+    <div className="p-4">
+      <JsonView
+        src={data}
+        editable={{ add: true, edit: true, delete: true }}
+        onEdit={({ src }) => update(src)}
+        onAdd={({ src }) => update(src)}
+        onDelete={({ src }) => update(src)}
+        style={{ backgroundColor: 'transparent' }}
+        theme="github"
+      />
+    </div>
+  )
+}
+
+export default DataTreeEditor


### PR DESCRIPTION
## Summary
- add `react18-json-view` for interactive tree editing
- implement `DataTreeEditor` component that auto-saves edits to IndexedDB
- expose new `/update` page for editing report data

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685fbe6a52688321a06a8a48427f6976