### PR TITLE
fix saving report data when editing

### DIFF
--- a/src/components/DataTreeEditor.tsx
+++ b/src/components/DataTreeEditor.tsx
@@ -12,7 +12,7 @@ const DataTreeEditor = () => {
   const update = (src: unknown) => {
     const cloned = JSON.parse(JSON.stringify(src)) as ReportData
     setData(cloned)
-    save()
+    save(cloned)
   }
 
   return (

--- a/src/contexts/ReportContext.tsx
+++ b/src/contexts/ReportContext.tsx
@@ -6,7 +6,7 @@ import { db, REPORT_ID, resetReportData } from '@/utils/db'
 type ReportContextType = {
   data: ReportData | null
   setData: React.Dispatch<React.SetStateAction<ReportData | null>>
-  save: () => Promise<void>
+  save: (newData?: ReportData) => Promise<void>
   reset: () => Promise<void>
   editing: boolean
   toggleEditing: () => void
@@ -37,9 +37,10 @@ export const ReportProvider = ({ children }: { children: React.ReactNode }) => {
     load()
   }, [])
 
-  const save = async () => {
-    if (!data) return
-    await db.table('report').put({ ...(data as ReportData), id: REPORT_ID })
+  const save = async (newData?: ReportData) => {
+    const toSave = newData ?? data
+    if (!toSave) return
+    await db.table('report').put({ ...(toSave as ReportData), id: REPORT_ID })
   }
 
   const reset = async () => {


### PR DESCRIPTION
## Summary
- fix saving data directly from state updates
- allow `save` to take optional new data to persist

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685fc49102cc8321ae4a298345403654