### PR TITLE
Add floating DataTreeEditor

### DIFF
--- a/src/components/SettingsFloat.tsx
+++ b/src/components/SettingsFloat.tsx
@@ -1,10 +1,21 @@
 'use client'
 import { resetReportData } from '@/utils/db'
-import { RefreshCcw, Pencil, Eye, Printer, Save } from 'lucide-react'
+import {
+  RefreshCcw,
+  Pencil,
+  Eye,
+  Printer,
+  Save,
+  ListTree,
+  X,
+} from 'lucide-react'
+import { useState } from 'react'
+import DataTreeEditor from './DataTreeEditor'
 import { useReport } from '@/contexts/ReportContext'
 
 const SettingsFloat = () => {
   const { editing, toggleEditing, save } = useReport()
+  const [showTree, setShowTree] = useState(false)
 
   const toggle = () => {
     toggleEditing()
@@ -21,24 +32,44 @@ const SettingsFloat = () => {
     }
   }
 
+  const toggleTree = () => setShowTree((o) => !o)
+
   const btn =
     'p-2 rounded-full text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-emerald-500'
 
   return (
-    <div className="fixed bottom-4 right-4 flex flex-col space-y-2 p-2 bg-white/70 backdrop-blur-md rounded-xl shadow z-50 print:hidden">
-      <button onClick={toggle} className={btn} title={editing ? 'View mode' : 'Edit mode'}>
-        {editing ? <Eye size={20} /> : <Pencil size={20} />}
-      </button>
-      <button onClick={() => save()} className={btn} title="Save changes">
-        <Save size={20} />
-      </button>
-      <button onClick={reset} className={btn} title="Reset data">
-        <RefreshCcw size={20} />
-      </button>
-      <button onClick={print} className={btn} title="Print">
-        <Printer size={20} />
-      </button>
-    </div>
+    <>
+      <div
+        className={`fixed top-0 right-0 h-full w-full max-w-xl bg-white shadow-lg z-50 transform transition-transform ${showTree ? 'translate-x-0' : 'translate-x-full'}`}
+      >
+        <div className="flex items-center justify-between p-2 border-b">
+          <h2 className="font-semibold">Report Data</h2>
+          <button onClick={toggleTree} className={btn} title="Close editor">
+            <X size={20} />
+          </button>
+        </div>
+        <div className="overflow-y-auto h-[calc(100%-48px)]">
+          <DataTreeEditor />
+        </div>
+      </div>
+      <div className="fixed bottom-4 right-4 flex flex-col space-y-2 p-2 bg-white/70 backdrop-blur-md rounded-xl shadow z-40 print:hidden">
+        <button onClick={toggle} className={btn} title={editing ? 'View mode' : 'Edit mode'}>
+          {editing ? <Eye size={20} /> : <Pencil size={20} />}
+        </button>
+        <button onClick={() => save()} className={btn} title="Save changes">
+          <Save size={20} />
+        </button>
+        <button onClick={reset} className={btn} title="Reset data">
+          <RefreshCcw size={20} />
+        </button>
+        <button onClick={print} className={btn} title="Print">
+          <Printer size={20} />
+        </button>
+        <button onClick={toggleTree} className={btn} title="Edit data tree">
+          <ListTree size={20} />
+        </button>
+      </div>
+    </>
   )
 }
 

--- a/src/components/SettingsFloat.tsx
+++ b/src/components/SettingsFloat.tsx
@@ -39,19 +39,19 @@ const SettingsFloat = () => {
 
   return (
     <>
-      {/* Backdrop */}
+      {/* Backdrop to catch outside clicks */}
       {showTree && (
         <div
           onClick={toggleTree}
-          className="fixed inset-0 bg-black/30 backdrop-blur-sm z-40 transition-opacity print:hidden"
+          className="fixed inset-0 z-40 print:hidden"
         />
       )}
       {/* Sliding panel */}
       <aside
-        className={`fixed top-0 right-0 h-full w-full max-w-xl bg-white rounded-l-xl shadow-2xl z-50 transform transition-transform duration-300 ease-in-out print:hidden ${showTree ? 'translate-x-0' : 'translate-x-full'}`}
+        className={`fixed top-0 right-0 h-full w-full max-w-xl bg-white rounded-l-xl shadow-lg z-50 transform transition-transform duration-300 ease-in-out print:hidden ${showTree ? 'translate-x-0' : 'translate-x-full'}`}
       >
         <div className="flex items-center justify-between p-3 border-b">
-          <h2 className="font-semibold">Report Data</h2>
+          <h2 className="font-semibold">Edit Report Data</h2>
           <button onClick={toggleTree} className={btn} title="Close editor">
             <X size={20} />
           </button>

--- a/src/components/SettingsFloat.tsx
+++ b/src/components/SettingsFloat.tsx
@@ -39,10 +39,18 @@ const SettingsFloat = () => {
 
   return (
     <>
-      <div
-        className={`fixed top-0 right-0 h-full w-full max-w-xl bg-white shadow-lg z-50 transform transition-transform ${showTree ? 'translate-x-0' : 'translate-x-full'}`}
+      {/* Backdrop */}
+      {showTree && (
+        <div
+          onClick={toggleTree}
+          className="fixed inset-0 bg-black/30 backdrop-blur-sm z-40 transition-opacity print:hidden"
+        />
+      )}
+      {/* Sliding panel */}
+      <aside
+        className={`fixed top-0 right-0 h-full w-full max-w-xl bg-white rounded-l-xl shadow-2xl z-50 transform transition-transform duration-300 ease-in-out print:hidden ${showTree ? 'translate-x-0' : 'translate-x-full'}`}
       >
-        <div className="flex items-center justify-between p-2 border-b">
+        <div className="flex items-center justify-between p-3 border-b">
           <h2 className="font-semibold">Report Data</h2>
           <button onClick={toggleTree} className={btn} title="Close editor">
             <X size={20} />
@@ -51,7 +59,8 @@ const SettingsFloat = () => {
         <div className="overflow-y-auto h-[calc(100%-48px)]">
           <DataTreeEditor />
         </div>
-      </div>
+      </aside>
+      {/* Floating button group */}
       <div className="fixed bottom-4 right-4 flex flex-col space-y-2 p-2 bg-white/70 backdrop-blur-md rounded-xl shadow z-40 print:hidden">
         <button onClick={toggle} className={btn} title={editing ? 'View mode' : 'Edit mode'}>
           {editing ? <Eye size={20} /> : <Pencil size={20} />}


### PR DESCRIPTION
## Summary
- open a sliding DataTreeEditor from SettingsFloat
- allow closing the panel and editing the data tree anywhere

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685fc98259048321ae001f7bb036d8c3