### PR TITLE
Apply page-specific margins for print

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -54,6 +54,7 @@ body {
   }
   
   body {
+    margin: 0;
     -webkit-print-color-adjust: exact !important;
     print-color-adjust: exact !important;
     background: white !important;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -44,7 +44,13 @@ body {
 
 @media print {
   @page {
-    margin: 0.5cm;
+    margin-top: 1.5cm;
+    margin-bottom: 1.5cm;
+  }
+
+  @page :first {
+    margin-top: 0;
+    margin-bottom: 0;
   }
   
   body {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,6 +35,7 @@ const HomePage = () => {
             }
             
             body {
+              margin: 0;
               -webkit-print-color-adjust: exact !important;
               print-color-adjust: exact !important;
               background: white !important;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,8 +12,9 @@ const HomePage = () => {
         <style>{`
           @media print {
             @page {
-              margin: 1.5cm;
-
+              margin-top: 1.5cm;
+              margin-bottom: 1.5cm;
+              
               @bottom-center {
                 content: "Page " counter(page);
                 font-size: 11pt;
@@ -26,7 +27,8 @@ const HomePage = () => {
             }
             
             @page :first {
-              margin: 0;
+              margin-top: 0;
+              margin-bottom: 0;
               @bottom-center {
                 content: none;
               }


### PR DESCRIPTION
## Summary
- adjust global print styles to use different top/bottom margins
- tweak inline print styles on the report page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685fc9da3f308321a9a3bad7765c21fe