### PR TITLE
Add theme context and toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,11 @@
   }
 }
 
+html.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import "./globals.css";
 import SettingsFloat from "@/components/SettingsFloat";
 import { inter } from "@/fonts";
 import { ReportProvider } from "@/contexts/ReportContext";
+import { ThemeProvider } from "@/contexts/ThemeContext";
 import { reportData } from "@/data/report";
 
 export const metadata = {
@@ -17,10 +18,12 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <ReportProvider>
-          {children}
-          <SettingsFloat />
-        </ReportProvider>
+        <ThemeProvider>
+          <ReportProvider>
+            {children}
+            <SettingsFloat />
+          </ReportProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/SettingsFloat.tsx
+++ b/src/components/SettingsFloat.tsx
@@ -7,15 +7,19 @@ import {
   Printer,
   Save,
   ListTree,
+  Sun,
+  Moon,
   X,
 } from 'lucide-react'
 import { useState } from 'react'
+import { useTheme } from '@/contexts/ThemeContext'
 import DataTreeEditor from './DataTreeEditor'
 import { useReport } from '@/contexts/ReportContext'
 
 const SettingsFloat = () => {
   const { editing, toggleEditing, save } = useReport()
   const [showTree, setShowTree] = useState(false)
+  const { theme, toggleTheme } = useTheme()
 
   const toggle = () => {
     toggleEditing()
@@ -73,6 +77,9 @@ const SettingsFloat = () => {
         </button>
         <button onClick={print} className={btn} title="Print">
           <Printer size={20} />
+        </button>
+        <button onClick={toggleTheme} className={btn} title="Toggle theme">
+          {theme === 'dark' ? <Sun size={20} /> : <Moon size={20} />}
         </button>
         <button onClick={toggleTree} className={btn} title="Edit data tree">
           <ListTree size={20} />

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,50 @@
+'use client'
+import { createContext, useContext, useEffect, useState } from 'react'
+
+type Theme = 'light' | 'dark'
+
+interface ThemeContextType {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
+
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+  const [theme, setTheme] = useState<Theme>('light')
+
+  // Load stored preference on mount
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const stored = localStorage.getItem('theme') as Theme | null
+    if (stored === 'light' || stored === 'dark') {
+      setTheme(stored)
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark')
+    }
+  }, [])
+
+  // Apply theme class to html element
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    document.documentElement.classList.toggle('dark', theme === 'dark')
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  const toggleTheme = () =>
+    setTheme((t) => (t === 'light' ? 'dark' : 'light'))
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider')
+  return ctx
+}
+
+export default ThemeContext


### PR DESCRIPTION
## Summary
- implement a `ThemeContext` to manage dark and light themes
- attach `ThemeProvider` in the root layout
- support dark styles via `html.dark` in global CSS
- add theme toggle button inside the settings float panel

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685fd3cc142883219b56def2e34b8b0f