### PR TITLE
Update cover page logo placement

### DIFF
--- a/src/components/CoverPage.tsx
+++ b/src/components/CoverPage.tsx
@@ -13,7 +13,7 @@ const CoverPage = () => {
     <div className="absolute top-1/3 right-20 w-16 h-16 rounded-full bg-purple-200 opacity-50"></div>
     <div className="relative z-10 px-8 py-12 max-w-3xl mx-auto bg-transparent shadow-none">
       {data.logoImage && (
-        <div className="absolute bottom-0 right-0 w-40 h-40 hidden">
+        <div className="absolute top-6 left-1/2 -translate-x-1/2 w-32 h-32 opacity-70 mix-blend-multiply">
           <img
             src={data.logoImage.src}
             alt={data.logoImage.alt}

--- a/src/components/CoverPage.tsx
+++ b/src/components/CoverPage.tsx
@@ -13,7 +13,7 @@ const CoverPage = () => {
     <div className="absolute top-1/3 right-20 w-16 h-16 rounded-full bg-purple-200 opacity-50"></div>
     <div className="relative z-10 px-8 py-12 max-w-3xl mx-auto bg-transparent shadow-none">
       {data.logoImage && (
-        <div className="absolute top-6 left-1/2 -translate-x-1/2 w-32 h-32 opacity-70 mix-blend-multiply">
+        <div className="absolute left-1/2 -translate-x-1/2 w-70 h-32 opacity-80 mix-blend-multiply" style={{top: "-90px"}}>
           <img
             src={data.logoImage.src}
             alt={data.logoImage.alt}


### PR DESCRIPTION
## Summary
- reposition the logo to the top of the cover page
- use opacity and mix-blend for a subtle look

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862d60c00ac8321b144b326ef22c743