### PR TITLE
Add toast notification after saving

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-chartjs-2": "^5.3.0",
         "react-countup": "^6.5.3",
         "react-dom": "^19.0.0",
+        "react-hot-toast": "^2.5.2",
         "react-icons": "^5.5.0",
         "react-leaflet": "^5.0.0",
         "react18-json-view": "^0.2.9"
@@ -3210,7 +3211,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4396,6 +4396,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -6116,6 +6125,23 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-chartjs-2": "^5.3.0",
     "react-countup": "^6.5.3",
     "react-dom": "^19.0.0",
+    "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
     "react-leaflet": "^5.0.0",
     "react18-json-view": "^0.2.9"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import SettingsFloat from "@/components/SettingsFloat";
 import { inter } from "@/fonts";
 import { ReportProvider } from "@/contexts/ReportContext";
 import { reportData } from "@/data/report";
+import { Toaster } from "react-hot-toast";
 
 export const metadata = {
   title: reportData.pageTitle,
@@ -20,6 +21,7 @@ export default function RootLayout({
         <ReportProvider>
           {children}
           <SettingsFloat />
+          <Toaster position="top-right" />
         </ReportProvider>
       </body>
     </html>

--- a/src/contexts/ReportContext.tsx
+++ b/src/contexts/ReportContext.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, { createContext, useContext, useEffect, useState } from 'react'
+import { toast } from 'react-hot-toast'
 import { ReportData } from '@/types/report'
 import {
   fetchReportData,
@@ -40,6 +41,7 @@ export const ReportProvider = ({ children }: { children: React.ReactNode }) => {
     const toSave = newData ?? data
     if (!toSave) return
     await saveReportData(toSave as ReportData)
+    toast.success('Saved changes')
   }
 
   const reset = async () => {


### PR DESCRIPTION
## Summary
- add `react-hot-toast` dependency
- show toaster in root layout
- show success toast after saving to Firebase

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' errors)*

------
https://chatgpt.com/codex/tasks/task_e_68636f4abb70832198a584c50a9cc128