### PR TITLE
Add unsaved changes indicator

### DIFF
--- a/src/components/DataTreeEditor.tsx
+++ b/src/components/DataTreeEditor.tsx
@@ -5,14 +5,13 @@ import { useReport } from '@/contexts/ReportContext'
 import { ReportData } from '@/types/report'
 
 const DataTreeEditor = () => {
-  const { data, setData, save } = useReport()
+  const { data, setData } = useReport()
 
   if (!data) return <p>Loading...</p>
 
   const update = (src: unknown) => {
     const cloned = JSON.parse(JSON.stringify(src)) as ReportData
     setData(cloned)
-    save(cloned)
   }
 
   return (

--- a/src/components/SettingsFloat.tsx
+++ b/src/components/SettingsFloat.tsx
@@ -14,7 +14,7 @@ import DataTreeEditor from './DataTreeEditor'
 import { useReport } from '@/contexts/ReportContext'
 
 const SettingsFloat = () => {
-  const { editing, toggleEditing, save } = useReport()
+  const { editing, toggleEditing, save, dirty } = useReport()
   const [showTree, setShowTree] = useState(false)
 
   const toggle = () => {
@@ -66,7 +66,12 @@ const SettingsFloat = () => {
           {editing ? <Eye size={20} /> : <Pencil size={20} />}
         </button>
         <button onClick={() => save()} className={btn} title="Save changes">
-          <Save size={20} />
+          <div className="relative">
+            <Save size={20} />
+            {dirty && (
+              <span className="absolute -top-0 -right-0 w-2 h-2 bg-red-500 rounded-full animate-pulse" />
+            )}
+          </div>
         </button>
         <button onClick={reset} className={btn} title="Reset data">
           <RefreshCcw size={20} />


### PR DESCRIPTION
## Summary
- track unsaved edits in `ReportContext`
- remove auto-save from JSON tree editor
- show red dot on save icon when there are unsaved changes

## Testing
- `npm run lint` *(fails: `@typescript-eslint/no-unused-vars` in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_686376b975888321acff9993b8eeca1c