### PR TITLE
Add expenditure details to financials section

### DIFF
--- a/src/components/FinancialsSection.tsx
+++ b/src/components/FinancialsSection.tsx
@@ -626,19 +626,91 @@ const FinancialsSection = ({ number }: Props) => {
           className="bg-slate-50 px-6 py-3 text-sm text-slate-500 border-t border-slate-200"
           {...(editing
             ? {
-              contentEditable: true,
-              suppressContentEditableWarning: true,
-              onBlur: (e: React.FocusEvent<HTMLElement>) => {
-                const newData = { ...(data as typeof data) }
-                newData.financialAuditNote = e.currentTarget.textContent || ''
-                setData(newData)
-              },
-            }
+                contentEditable: true,
+                suppressContentEditableWarning: true,
+                onBlur: (e: React.FocusEvent<HTMLElement>) => {
+                  const newData = { ...(data as typeof data) }
+                  newData.financialAuditNote = e.currentTarget.textContent || ''
+                  setData(newData)
+                },
+              }
             : {})}
         >
           {data.financialAuditNote}
         </div>
       </div>
+
+      {data.financialPoints && (
+        <ul className="list-disc pl-6 mb-6 space-y-2">
+          {data.financialPoints.map((point, index) => (
+            <li
+              key={index}
+              className="text-lg"
+              {...(editing
+                ? {
+                    contentEditable: true,
+                    suppressContentEditableWarning: true,
+                    onBlur: (e: React.FocusEvent<HTMLElement>) => {
+                      const newData = { ...(data as typeof data) }
+                      if (newData.financialPoints)
+                        newData.financialPoints[index] =
+                          e.currentTarget.textContent || ''
+                      setData(newData)
+                    },
+                  }
+                : {})}
+            >
+              {point}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {data.expenditureIncreaseSummary && (
+        <p
+          className="text-lg text-gray-700 mb-2"
+          {...(editing
+            ? {
+                contentEditable: true,
+                suppressContentEditableWarning: true,
+                onBlur: (e: React.FocusEvent<HTMLElement>) => {
+                  const newData = { ...(data as typeof data) }
+                  newData.expenditureIncreaseSummary =
+                    e.currentTarget.textContent || ''
+                  setData(newData)
+                },
+              }
+            : {})}
+        >
+          {data.expenditureIncreaseSummary}
+        </p>
+      )}
+
+      {data.expenditureIncreaseReasons && (
+        <ul className="list-disc pl-6 mb-8 space-y-2">
+          {data.expenditureIncreaseReasons.map((reason, index) => (
+            <li
+              key={index}
+              className="text-lg"
+              {...(editing
+                ? {
+                    contentEditable: true,
+                    suppressContentEditableWarning: true,
+                    onBlur: (e: React.FocusEvent<HTMLElement>) => {
+                      const newData = { ...(data as typeof data) }
+                      if (newData.expenditureIncreaseReasons)
+                        newData.expenditureIncreaseReasons[index] =
+                          e.currentTarget.textContent || ''
+                      setData(newData)
+                    },
+                  }
+                : {})}
+            >
+              {reason}
+            </li>
+          ))}
+        </ul>
+      )}
 
     </div>
   )

--- a/src/data/report.json
+++ b/src/data/report.json
@@ -31,6 +31,19 @@
       "value": "8.6%"
     }
   ],
+  "financialPoints": [
+    "Scholarship expenditure increased by 49.3%",
+    "Irrigation garden projects increased by 6.8%",
+    "Staff expenses increased by 57.9%",
+    "Bank charges increased by over 100%"
+  ],
+  "expenditureIncreaseSummary": "Overall expenditure increased by 62% from last year and this is due to the following reasons:",
+  "expenditureIncreaseReasons": [
+    "An increase in scholarship beneficiaries",
+    "Motor vehicle purchase",
+    "Bank charges are high because we opened a bank account and its charges are costly",
+    "Adoption of a new school i.e. Chiroti (drilled a borehole and installed fence)"
+  ],
   "financials": {
     "expenses": [
       {

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -134,6 +134,9 @@ export interface ReportData {
   highlights?: HighlightStat[];
   financialsTitle: string;
   financialMetrics?: FinancialMetric[];
+  financialPoints?: string[];
+  expenditureIncreaseSummary?: string;
+  expenditureIncreaseReasons?: string[];
   financialIntro?: string;
   financials?: IncomeStatement;
   totalRevenueAmount?: string;


### PR DESCRIPTION
## Summary
- extend financial report types with new bullet list fields
- implement bullet lists in the FinancialsSection component
- add financial highlights and expenditure reasons to report data

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_686487214eb0832195d101c506c46f18