### PR TITLE
Resolve lint warnings

### DIFF
--- a/src/components/ImpactInfographic.tsx
+++ b/src/components/ImpactInfographic.tsx
@@ -44,20 +44,10 @@ const iconMap: Record<string, IconComponent> = {
 
 interface SectionProps {
   title: string
-  icon: IconComponent
-  color: Color
   children: React.ReactNode
 }
 
-const Section = ({ title, icon: Icon, color, children }: SectionProps) => {
-  const colorClasses: Record<Color, string> = {
-    blue: 'text-blue-600',
-    green: 'text-green-600',
-    purple: 'text-purple-600',
-    yellow: 'text-yellow-600',
-    pink: 'text-pink-600',
-    teal: 'text-teal-600',
-  }
+const Section = ({ title, children }: SectionProps) => {
   return (
     <div className="p-6 print:p-4">
       <h2 className="text-3xl font-bold text-slate-800 mb-10 flex items-baseline">
@@ -65,8 +55,8 @@ const Section = ({ title, icon: Icon, color, children }: SectionProps) => {
       </h2>
       {children}
     </div>
-  );
-};
+  )
+}
 
 
 interface StatCardProps {
@@ -178,7 +168,7 @@ const TTIInfographic = () => {
 
         <main>
           {/* Impact Section */}
-          <Section title={impact.title} icon={iconMap[impact.icon]} color={impact.color as Color}>
+          <Section title={impact.title}>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
               {/* Stats */}
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/src/components/ReportViewer.tsx
+++ b/src/components/ReportViewer.tsx
@@ -10,8 +10,6 @@ import StrategicVisionSection from './StrategicVisionSection';
 import Sections from './Sections';
 import FinancialsSection from './FinancialsSection';
 import FutureGoalsSection from './FutureGoalsSection';
-import dynamic from 'next/dynamic';
-const MapSection = dynamic(() => import('./MapSection'), { ssr: false });
 import ClosingSection from './ClosingSection';
 import TTIInfographic from './ImpactInfographic';
 

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -1,6 +1,5 @@
 'use client'
 import { Dispatch, SetStateAction } from 'react'
-import { BookOpen } from 'lucide-react'
 import { useReport } from '@/contexts/ReportContext'
 
 interface TocItem {

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -99,7 +99,7 @@ export interface InfographicData {
 }
 
 export interface ReportData {
-  financialPointsHeading: any;
+  financialPointsHeading?: string;
   pageTitle: string;
   pageDescription: string;
   organization: string;


### PR DESCRIPTION
## Summary
- clean up unused parameters in `ImpactInfographic`
- remove unused MapSection import
- drop unused BookOpen icon
- type `financialPointsHeading` as a string

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68648e9bc2d08321af33216bf7a190b0