### PR TITLE
Apply print paragraph font size

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -58,6 +58,10 @@ body {
     print-color-adjust: exact !important;
     background: white !important;
   }
+
+  p {
+    font-size: 10pt;
+  }
   
   .print\:break-before {
     page-break-before: always;


### PR DESCRIPTION
## Summary
- tweak print styles to use smaller font size for paragraphs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686495fb4f5483219136fdeecaea855d